### PR TITLE
Implement UT to backend configuration

### DIFF
--- a/kaprien_api/__init__.py
+++ b/kaprien_api/__init__.py
@@ -1,4 +1,5 @@
 import importlib
+import os
 
 from dynaconf import Dynaconf
 
@@ -6,7 +7,7 @@ from kaprien_api import services  # noqa
 from kaprien_api.tuf import MetadataRepository
 from kaprien_api.tuf.interfaces import IKeyVault, IStorage
 
-SETTINGS_FILE = "settings.ini"
+SETTINGS_FILE = os.getenv("SETTINGS_FILE", "settings.ini")
 settings = Dynaconf(
     envvar_prefix="KAPRIEN",
     settings_files=[SETTINGS_FILE],

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,11 +1,10 @@
 import pytest
 from fastapi.testclient import TestClient
 
-from app import kaprien_app
-
 
 @pytest.fixture
 def test_client():
+    from app import kaprien_app
 
     client = TestClient(kaprien_app)
 

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -1,4 +1,47 @@
+from tempfile import TemporaryDirectory
+
+import pytest
 from fastapi import status
+
+
+def test_wrong_storage_backend(monkeypatch):
+    monkeypatch.setenv("KAPRIEN_STORAGE_BACKEND", "InvalidStorage")
+
+    with pytest.raises(ValueError) as err:
+        from app import kaprien_app  # noqa
+
+    assert "Invalid Storage Backend InvalidStorage" in str(err.value)
+
+
+def test_localstorage_backend_missing_required_argument(monkeypatch):
+    monkeypatch.setenv("SETTINGS_FILE", f"{TemporaryDirectory}/settings.ini")
+    monkeypatch.setenv("KAPRIEN_STORAGE_BACKEND", "LocalStorage")
+
+    with pytest.raises(AttributeError) as err:
+        from app import kaprien_app  # noqa
+
+    assert "not attribute(s) LOCAL_STORAGE_BACKEND_PATH" in str(err.value)
+
+
+def test_wrong_keyvault_backend(monkeypatch):
+    monkeypatch.setenv("KAPRIEN_KEYVAULT_BACKEND", "InvalidKeyVault")
+
+    with pytest.raises(ValueError) as err:
+        from app import kaprien_app  # noqa
+
+    assert "Invalid Key Vault Backend InvalidKeyVault" in str(err.value)
+
+
+def test_localkeyvault_backend_missing_required_argument(monkeypatch):
+    monkeypatch.setenv("SETTINGS_FILE", f"{TemporaryDirectory}/settings.ini")
+    monkeypatch.setenv("KAPRIEN_STORAGE_BACKEND", "LocalStorage")
+    monkeypatch.setenv("KAPRIEN_LOCAL_STORAGE_BACKEND_PATH", "storage/")
+    monkeypatch.setenv("KAPRIEN_KEYVAULT_BACKEND", "LocalKeyVault")
+
+    with pytest.raises(AttributeError) as err:
+        from app import kaprien_app  # noqa
+
+    assert "not attribute(s) LOCAL_KEYVAULT_PATH" in str(err.value)
 
 
 def test_root(test_client):


### PR DESCRIPTION
This commit implements UT to the backend configurations and adds some
changes to the conftest to avoid loading configuration to the all test
environment.

Closes #23 

Signed-off-by: Kairo de Araujo <kairo@kairo.eti.br>