### PR TITLE
Implement the endpoint GET `settings`

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, FastAPI
 
 from kaprien_api.api.bootstrap import router as bootstrap_v1
 from kaprien_api.api.metadata import router as metadata_v1
+from kaprien_api.api.repository_settings import router as settings_v1
 
 kaprien_app = FastAPI(
     docs_url="/",
@@ -17,6 +18,7 @@ api_v1 = APIRouter(
 
 api_v1.include_router(bootstrap_v1)
 api_v1.include_router(metadata_v1)
+api_v1.include_router(settings_v1)
 
 kaprien_app.include_router(api_v1)
 

--- a/kaprien_api/api/repository_settings.py
+++ b/kaprien_api/api/repository_settings.py
@@ -1,0 +1,19 @@
+from fastapi import APIRouter
+
+from kaprien_api import repository_settings
+
+router = APIRouter(
+    prefix="/settings",
+    tags=["v1"],
+    responses={404: {"description": "Not found"}},
+)
+
+
+@router.get(
+    "/",
+    description="Returns the Settings",
+    response_model=repository_settings.Response,
+    response_model_exclude_none=True,
+)
+def get():
+    return repository_settings.get()

--- a/kaprien_api/repository_settings.py
+++ b/kaprien_api/repository_settings.py
@@ -1,0 +1,81 @@
+import json
+from typing import Dict, Optional
+
+from fastapi import HTTPException, status
+
+from kaprien_api import settings, tuf, tuf_repository
+from kaprien_api.utils import BaseModel
+
+
+class CurrentSettingsServiceBackendParams(BaseModel):
+    required: bool
+    current_value: str
+
+
+class CurrentSettingsServiceBackend(BaseModel):
+    using: str
+    parameters: Optional[Dict[str, CurrentSettingsServiceBackendParams]]
+
+
+class CurrentSettings(BaseModel):
+    storage_backend: CurrentSettingsServiceBackend
+    keyvault_backend: CurrentSettingsServiceBackend
+    roles_expirations: Dict[str, int]
+
+
+class Response(BaseModel):
+    data: CurrentSettings
+    message: str
+
+    class Config:
+        with open(
+            "tests/data_examples/repository_settings/settings.json"
+        ) as f:
+            content = f.read()
+        example_settings = json.loads(content)
+
+        schema_extra = {
+            "example": {
+                "data": example_settings,
+                "message": "Current Settings",
+            }
+        }
+
+
+def get():
+    if tuf_repository.is_initialized is False:
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND,
+            detail={"error": "System has not a Repository Metadata"},
+        )
+    services_backend = {
+        "storage_backend": {
+            "using": settings.STORAGE_BACKEND.__name__,
+            "parameters": {
+                i.name: {
+                    "required": i.required,
+                    "current_value": settings.get(i.name),
+                }
+                for i in settings.STORAGE_BACKEND.settings()
+            },
+        },
+        "keyvault_backend": {
+            "using": settings.KEYVAULT_BACKEND.__name__,
+            "parameters": {
+                i.name: {
+                    "required": i.required,
+                    "current_value": settings.get(i.name),
+                }
+                for i in settings.KEYVAULT_BACKEND.settings()
+            },
+        },
+    }
+    roles_settings = {
+        "roles_expirations": {
+            role.value: settings.get(f"{role.value}_EXPIRATION")
+            for role in tuf.Roles
+        },
+    }
+    current_settings = {**services_backend, **roles_settings}
+
+    return Response(data=current_settings, message="Current Settings")

--- a/tests/data_examples/repository_settings/settings.json
+++ b/tests/data_examples/repository_settings/settings.json
@@ -1,0 +1,28 @@
+{
+    "storage_backend": {
+        "type": "LocalStorage",
+        "parameters": {
+            "LOCAL_STORAGE_BACKEND_PATH": {
+                "required": true,
+                "value": "metadata"
+            }
+        }
+    },
+    "keyvault_backend": {
+        "type": "LocalKeyVault",
+        "parameters": {
+            "LOCAL_KEYVAULT_PATH": {
+                "required": true,
+                "value": "keys"
+            }
+        }
+    },
+    "roles_expirations": {
+        "root": "356",
+        "targets": "365",
+        "snapshot": "1",
+        "timestamp": "1",
+        "bin": "365",
+        "bins": "1"
+    }
+}

--- a/tests/unit/api/test_repository_settings.py
+++ b/tests/unit/api/test_repository_settings.py
@@ -1,0 +1,75 @@
+import pretend
+from fastapi import status
+
+
+class TestGetSettings:
+    def test_get_settings(self, test_client, monkeypatch):
+        url = "/api/v1/settings"
+
+        fake_repo = pretend.stub(is_initialized=True)
+        monkeypatch.setattr(
+            "kaprien_api.repository_settings.tuf_repository", fake_repo
+        )
+
+        def fake_get(arg):
+            if "_EXPIRATION" in arg:
+                return 30
+            else:
+                return "fake_value"
+
+        fake_backend = pretend.stub(
+            name="FakeBackend",
+            required=True,
+        )
+        fake_settings = pretend.stub(
+            STORAGE_BACKEND=pretend.stub(
+                __name__="fake_storage_backend",
+                settings=pretend.call_recorder(lambda: [fake_backend]),
+            ),
+            KEYVAULT_BACKEND=pretend.stub(
+                __name__="fake_keyvault_backend",
+                settings=pretend.call_recorder(lambda: [fake_backend]),
+            ),
+            get=pretend.call_recorder(fake_get),
+        )
+        monkeypatch.setattr(
+            "kaprien_api.repository_settings.settings", fake_settings
+        )
+
+        test_response = test_client.get(url)
+        assert test_response.status_code == status.HTTP_200_OK
+        assert sorted(list(test_response.json()["data"].keys())) == [
+            "keyvault_backend",
+            "roles_expirations",
+            "storage_backend",
+        ]
+        assert test_response.json()["message"] == "Current Settings"
+        assert fake_settings.STORAGE_BACKEND.settings.calls == [pretend.call()]
+        assert fake_settings.KEYVAULT_BACKEND.settings.calls == [
+            pretend.call()
+        ]
+        assert fake_settings.get.calls == [
+            pretend.call("FakeBackend"),
+            pretend.call("FakeBackend"),
+            pretend.call("root_EXPIRATION"),
+            pretend.call("targets_EXPIRATION"),
+            pretend.call("snapshot_EXPIRATION"),
+            pretend.call("timestamp_EXPIRATION"),
+            pretend.call("bin_EXPIRATION"),
+            pretend.call("bins_EXPIRATION"),
+        ]
+
+    def test_get_settings_without_bootstrap(self, test_client, monkeypatch):
+        url = "/api/v1/settings"
+
+        fake_repo = pretend.stub(is_initialized=False)
+        monkeypatch.setattr(
+            "kaprien_api.repository_settings.tuf_repository", fake_repo
+        )
+
+        test_response = test_client.get(url)
+        assert test_response.status_code == status.HTTP_404_NOT_FOUND
+        assert (
+            test_response.json().get("detail").get("error")
+            == "System has not a Repository Metadata"
+        )


### PR DESCRIPTION
The GET `settings` retrieves the current settings used by the Kaprien API
Repository Server.

Closes #25 
Signed-off-by: Kairo de Araujo <kairo@kairo.eti.br>