### PR TITLE
Include the kaprien-mq container in development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+# Dockerfile
+#
+
+# Base
+FROM python:3.10-slim-buster as base_os
+
+# Builder requirements and deps
+FROM base_os as builder
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ADD requirements.txt /builder/requirements.txt
+
+WORKDIR /builder
+RUN apt-get update && apt-get install libpq-dev gcc -y
+RUN pip install --user -r requirements.txt
+RUN apt-get remove gcc --purge -y \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean autoclean \
+    && apt-get autoremove --yes
+
+# Final image
+FROM base_os as pre-final
+RUN apt-get update && apt-get install libpq-dev -y && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /root/.local/bin /usr/local/bin/
+COPY --from=builder /root/.local/lib/python3.10/site-packages /usr/local/lib/python3.10/site-packages/
+
+# Final stage
+FROM pre-final
+
+WORKDIR /opt/kaprien-rest-api
+
+COPY app.py /opt/kaprien-rest-api
+COPY kaprien_api /opt/kaprien-rest-api/kaprien_api
+COPY tests /opt/kaprien-rest-api/tests

--- a/Makefile
+++ b/Makefile
@@ -14,3 +14,18 @@ requirements:
 coverage:
 	coverage report
 	coverage html -i
+
+build-dev:
+	docker build -t kaprien-rest-api:dev .
+
+run-dev:
+	$(MAKE) build-dev
+	docker-compose up --remove-orphans
+
+stop:
+	docker-compose down -v
+
+clean:
+	docker-compose rm --force
+	rm -rf metadata/*
+	rm -rf keys/*

--- a/README.md
+++ b/README.md
@@ -3,16 +3,37 @@
 ---
 **NOTE**
 
-This project still not functional. Please wait for the first functional release
+This project is not functional. Please wait for the first functional release
 (0.0.1)
 
 ---
 
 The Kaprien REST API is a RESTful API for Kaprien.
 
-Currently, the API is not functional as it is still in the Specification development and project structure phase.
+The Kaprien REST API features
+- Server
+  - [x] Bootstrap the Kaprien Service (initial TUF Metadata) (_sync_)
+  - [x] Retrieves the latest Metadata as JSON rest API (_sync_)
+  - [x] Retrieves the Kaprien Service/Metadata settings (_sync_)
+- Targets
+  - [ ] Add a new target file from Metadata (_async_)
+  - [ ] Delete a target file from Metadata (_async_)
+- Metadata
+  - [ ] Bump Snapshot Metadata (_async_)
+  - [ ] Bump Timestamp Metadata (_async_)
+  - [ ] Bump BINS Metadata (_async_)
+  - [ ] Key rotation (_async_)
 
-```
+
+The _sync_ actions are handled directly to the Metadata using the
+choosed Storage Backend (`KAPRIEN_STORAGE_BACKEND`), the _async_ actions are
+submitted to the Message Queue (`kaprien-mq`) and are handled by the Kaprien
+Metadata Worker (`kaprien-worker`) that will manage the Metadata.
+
+TODO: Design decisionChange to all asynchronous to avoid duplicated implementation?
+- https://github.com/KAPRIEN/kaprien/issues/5
+
+
 
 ## Development
 
@@ -37,12 +58,15 @@ $ pipenv install -d
 Runing the API locally
 
 ```shell
-$ uvicorn app:kaprien_app --reload
+$ make serve-dev
 ```
 
 Open http://localhost:8000/ in your browser.
 
-## Tests
+Changes in the code will automatically update the service.
+
+See Makefile for more options
+### Tests
 
 We use [Tox](https://tox.wiki/en/latest/) to manage running the tests.
 
@@ -51,7 +75,7 @@ Running tests
 $ tox
 ```
 
-## Managing the requirements
+### Managing the requirements
 
 Installing new requirements
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,44 @@
+version: "3.9"
+
+volumes:
+  kaprien-mq-data:
+  kaprien-storage:
+  kaprien-keystorage:
+  kaprien-settings:
+
+services:
+  kaprien-mq:
+    image: rabbitmq:3-management-alpine
+    container_name: kaprien-mq
+    ports:
+      - 5672:5672
+    volumes:
+     - "kaprien-mq-data:/var/lib/rabbitmq"
+     - "kaprien-storage:/var/opt/kaprien/storage"
+     - "kaprien-keystorage:/var/opt/kaprien/keystorage"
+     - "kaprien-settings:/var/opt/kaprien/settings/"
+    healthcheck:
+      test: "exit 0"
+    restart: always
+    tty: true
+
+  kaprien-rest-api:
+    build:
+      context: .
+    command: uvicorn app:kaprien_app --host 0.0.0.0 --port 8000 --reload
+    ports:
+      - 8000:8000
+    environment:
+      - KAPRIEN_STORAGE_BACKEND="LocalStorage"
+      - KAPRIEN_KEYVAULT_BACKEND="LocalKeyVault"
+      - KAPRIEN_LOCAL_STORAGE_BACKEND_PATH="/var/opt/kaprien/storage"
+      - KAPRIEN_LOCAL_KEYVAULT_PATH="/var/opt/kaprien/keystorage"
+    volumes:
+      - ./kaprien_api:/opt/kaprien-rest-api/kaprien_api:z
+      - ./kaprien_api:/opt/kaprien-rest-api/test:z
+      - kaprien-storage:/var/opt/kaprien/storage
+      - kaprien-keystorage:/var/opt/kaprien/keystorage
+      - kaprien-settings:/var/opt/kaprien/settings/
+    depends_on:
+      kaprien-mq:
+        condition: service_healthy


### PR DESCRIPTION
This commit introduces the kaprien-mq as a RabbitMQ container that will
be used directly by kaprien-rest-api.
Any action to the Kaprien TUF Metadata will not be handled directly by
the kaprien-rest-api in the metadata, but it will be sent to a message
queue.
The actions in the TUF Metadata will be handled by another service named
kaprien-worker.
It avoids race conditions and enables the scalability of the deployment.

This service is now handled only in development environment.

Closes #35

Signed-off-by: Kairo de Araujo <kairo@kairo.eti.br>