### PR TITLE
Implement a new endpoint to add targets

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, FastAPI
 from kaprien_api.api.bootstrap import router as bootstrap_v1
 from kaprien_api.api.metadata import router as metadata_v1
 from kaprien_api.api.repository_settings import router as settings_v1
+from kaprien_api.api.targets import router as targets_v1
 
 kaprien_app = FastAPI(
     docs_url="/",
@@ -19,6 +20,7 @@ api_v1 = APIRouter(
 api_v1.include_router(bootstrap_v1)
 api_v1.include_router(metadata_v1)
 api_v1.include_router(settings_v1)
+api_v1.include_router(targets_v1)
 
 kaprien_app.include_router(api_v1)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,8 +34,7 @@ services:
       - KAPRIEN_LOCAL_STORAGE_BACKEND_PATH="/var/opt/kaprien/storage"
       - KAPRIEN_LOCAL_KEYVAULT_PATH="/var/opt/kaprien/keystorage"
     volumes:
-      - ./kaprien_api:/opt/kaprien-rest-api/kaprien_api:z
-      - ./kaprien_api:/opt/kaprien-rest-api/test:z
+      - ./:/opt/kaprien-rest-api:z
       - kaprien-storage:/var/opt/kaprien/storage
       - kaprien-keystorage:/var/opt/kaprien/keystorage
       - kaprien-settings:/var/opt/kaprien/settings/

--- a/kaprien_api/api/targets.py
+++ b/kaprien_api/api/targets.py
@@ -1,0 +1,19 @@
+from fastapi import APIRouter
+
+from kaprien_api import targets
+
+router = APIRouter(
+    prefix="/targets",
+    tags=["v1"],
+    responses={404: {"description": "Not found"}},
+)
+
+
+@router.post(
+    "/",
+    description="Add targets files to Metadata",
+    response_model=targets.Response,
+    response_model_exclude_none=True,
+)
+def post(payload: targets.Payload):
+    return targets.post(payload)

--- a/kaprien_api/targets.py
+++ b/kaprien_api/targets.py
@@ -1,0 +1,51 @@
+import json
+from typing import Any, Dict, List, Optional
+
+from kaprien_api.utils import BaseModel
+
+
+class Response(BaseModel):
+    data: Optional[List[str]]
+    message: Optional[str]
+
+    class Config:
+        data_example = {
+            "data": {"targets": ["file1.tar.gz", "file2.tar.gz"]},
+            "message": "Target files successfully added.",
+        }
+        schema_extra = {"example": data_example}
+
+
+class PayloadTargetsHashes(BaseModel):
+    blake2b_256: str
+
+    class Config:
+        fields = {"blake2b_256": "blake2b-256"}
+
+
+class TargetsInfo(BaseModel):
+    length: int
+    hashes: PayloadTargetsHashes
+    custom: Optional[Dict[str, Any]]
+
+
+class Targets(BaseModel):
+    info: TargetsInfo
+    path: str
+
+
+class Payload(BaseModel):
+    targets: List[Targets]
+
+    class Config:
+        with open("tests/data_examples/targets/payload.json") as f:
+            content = f.read()
+        payload = json.loads(content)
+        schema_extra = {"example": payload}
+
+
+def post(payload):
+
+    # TODO: Implement the publisher to the kaprien-mq (issue #39)
+    data = [target.path for target in payload.targets]
+    return Response(data=data, message="Target file(s) successfully added.")

--- a/tests/data_examples/targets/payload.json
+++ b/tests/data_examples/targets/payload.json
@@ -1,0 +1,24 @@
+{
+    "targets": [
+        {
+            "info": {
+                "length": 11342,
+                "hashes": {
+                    "blake2b-256": "716f6e863f744b9ac22c97ec7b76ea5f5908bc5b2f67c61510bfc4751384ea7a"
+                },
+                "custom": {"key": "value"}
+            },
+            "path": "file1.tar.gz"
+        },
+        {
+            "info": {
+                "length": 630,
+                "hashes": {
+                    "blake2b-256": "69217a3079908094e11121d042354a7c1f55b6482ca1a51e1b250dfd1ed0eef9"
+                },
+                "custom": {"key": "value"}
+            },
+            "path": "file2.tar.gz"
+        }
+    ]
+}

--- a/tests/unit/api/test_targets.py
+++ b/tests/unit/api/test_targets.py
@@ -1,0 +1,35 @@
+import json
+
+from fastapi import status
+
+
+class TestPostTargets:
+    def test_post(self, test_client):
+        url = "/api/v1/targets/"
+        with open("tests/data_examples/targets/payload.json") as f:
+            f_data = f.read()
+
+        payload = json.loads(f_data)
+
+        response = test_client.post(url, json=payload)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == {
+            "data": ["file1.tar.gz", "file2.tar.gz"],
+            "message": "Target file(s) successfully added.",
+        }
+
+    def test_post_missing_required_field(self, test_client):
+        url = "/api/v1/targets/"
+        payload = {
+            "targets": [
+                {
+                    "info": {
+                        "length": 11342,
+                        "custom": {"key": "value"},
+                    },
+                }
+            ]
+        }
+
+        response = test_client.post(url, json=payload)
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY


### PR DESCRIPTION
This commit implements the endpoint `/api/v1/targets` with method `POST`
to add new targets to the Metadata Repository.
This implementation adds the endpoint, documentation for the required
JSON payload and the response body.

This commit does not submit the targets to the message queue, it needs
to be implemented by #39.

A small fix in the development `docker-compose.yml` was added in order
to refresh automatically in case of changes in the `app.py`

Closes #38 
Signed-off-by: Kairo de Araujo <kairo@kairo.eti.br>