### PR TITLE
Publish 'add_targets' to the kaprien-mq

### DIFF
--- a/.github/workflows/test_docker_build.yml
+++ b/.github/workflows/test_docker_build.yml
@@ -24,7 +24,7 @@ jobs:
       uses: docker/login-action@v1
       with:
         registry: ghcr.io
-        username: ${{ github.repository_owner }}
+        username: ${{ secrets.GPR_OWNER }}
         password: ${{ secrets.GPR_TOKEN }}
 
     - name: Build and push

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     container_name: kaprien-mq
     ports:
       - 5672:5672
+      - 15672:15672
     volumes:
      - "kaprien-mq-data:/var/lib/rabbitmq"
      - "kaprien-storage:/var/opt/kaprien/storage"

--- a/kaprien_api/__init__.py
+++ b/kaprien_api/__init__.py
@@ -1,5 +1,4 @@
 import importlib
-import logging
 import os
 
 from celery import Celery
@@ -11,6 +10,12 @@ from kaprien_api.tuf.interfaces import IKeyVault, IStorage
 
 SETTINGS_FILE = os.getenv("SETTINGS_FILE", "settings.ini")
 settings = Dynaconf(
+    envvar_prefix="KAPRIEN",
+    settings_files=[SETTINGS_FILE],
+    environments=True,
+)
+
+simple_settings = Dynaconf(
     envvar_prefix="KAPRIEN",
     settings_files=[SETTINGS_FILE],
     environments=True,
@@ -98,6 +103,5 @@ celery.conf.broker_pool_limit = None
 
 
 @celery.task(name="app.metadata_repository")
-def submit_task(data):
-    logging.info(data)
+def repository_metadata(action, settings, payload):
     return True

--- a/kaprien_api/targets.py
+++ b/kaprien_api/targets.py
@@ -1,17 +1,26 @@
 import json
 from typing import Any, Dict, List, Optional
 
-from kaprien_api.utils import BaseModel
+from kaprien_api import repository_metadata, simple_settings
+from kaprien_api.utils import BaseModel, task_id
+
+
+class ResponseData(BaseModel):
+    targets: List[str]
+    task_id: str
 
 
 class Response(BaseModel):
-    data: Optional[List[str]]
+    data: Optional[ResponseData]
     message: Optional[str]
 
     class Config:
         data_example = {
-            "data": {"targets": ["file1.tar.gz", "file2.tar.gz"]},
-            "message": "Target files successfully added.",
+            "data": {
+                "targets": ["file1.tar.gz", "file2.tar.gz"],
+                "task_id": "06ee6db3cbab4b26be505352c2f2e2c3",
+            },
+            "message": "Target(s) successfully submitted.",
         }
         schema_extra = {"example": data_example}
 
@@ -45,7 +54,18 @@ class Payload(BaseModel):
 
 
 def post(payload):
-
-    # TODO: Implement the submission to the kaprien-mq (issue #43)
-    data = [target.path for target in payload.targets]
-    return Response(data=data, message="Target file(s) successfully added.")
+    add_targets_id = task_id()
+    repository_metadata.apply_async(
+        kwargs={
+            "action": "add_targets",
+            "settings": simple_settings.to_dict(),
+            "payload": payload.dict(by_alias=True),
+        },
+        task_id=add_targets_id,
+        queue="metadata_repository",
+    )
+    data = {
+        "targets": [target.path for target in payload.targets],
+        "task_id": add_targets_id,
+    }
+    return Response(data=data, message="Target(s) successfully submitted.")

--- a/kaprien_api/utils.py
+++ b/kaprien_api/utils.py
@@ -1,4 +1,5 @@
 from typing import Any, Dict, List, Literal, Optional
+from uuid import uuid4
 
 from dynaconf import loaders
 from dynaconf.utils.boxing import DynaBox
@@ -87,3 +88,7 @@ def save_settings(key: str, value: Any):
         DynaBox(settings_data).to_dict(),
         env=settings.current_env,
     )
+
+
+def task_id():
+    return uuid4().hex

--- a/tests/unit/api/test_targets.py
+++ b/tests/unit/api/test_targets.py
@@ -1,22 +1,50 @@
 import json
+from uuid import uuid4
 
+import pretend
 from fastapi import status
 
 
 class TestPostTargets:
-    def test_post(self, test_client):
+    def test_post(self, monkeypatch, test_client):
+        from kaprien_api import simple_settings  # noqa
+
         url = "/api/v1/targets/"
         with open("tests/data_examples/targets/payload.json") as f:
             f_data = f.read()
 
         payload = json.loads(f_data)
-
+        mocked_repository_metadata = pretend.stub(
+            apply_async=pretend.call_recorder(lambda *a, **kw: None)
+        )
+        fake_task_id = uuid4().hex
+        monkeypatch.setattr(
+            "kaprien_api.targets.repository_metadata",
+            mocked_repository_metadata,
+        )
+        monkeypatch.setattr(
+            "kaprien_api.targets.task_id", lambda: fake_task_id
+        )
         response = test_client.post(url, json=payload)
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == {
-            "data": ["file1.tar.gz", "file2.tar.gz"],
-            "message": "Target file(s) successfully added.",
+            "data": {
+                "targets": ["file1.tar.gz", "file2.tar.gz"],
+                "task_id": fake_task_id,
+            },
+            "message": "Target(s) successfully submitted.",
         }
+        assert mocked_repository_metadata.apply_async.calls == [
+            pretend.call(
+                kwargs={
+                    "action": "add_targets",
+                    "settings": simple_settings.to_dict(),
+                    "payload": payload,
+                },
+                task_id=fake_task_id,
+                queue="metadata_repository",
+            )
+        ]
 
     def test_post_missing_required_field(self, test_client):
         url = "/api/v1/targets/"

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -2,7 +2,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 
-@pytest.fixture
+@pytest.fixture(scope="class")
 def test_client():
     from app import kaprien_app
 

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -1,3 +1,4 @@
+import os
 from tempfile import TemporaryDirectory
 
 import pytest
@@ -5,6 +6,8 @@ from fastapi import status
 
 
 def test_wrong_storage_backend(monkeypatch):
+    tmp = TemporaryDirectory().name
+    monkeypatch.setenv("SETTINGS_FILE", os.path.join(tmp, "settings.ini"))
     monkeypatch.setenv("KAPRIEN_STORAGE_BACKEND", "InvalidStorage")
 
     with pytest.raises(ValueError) as err:
@@ -14,7 +17,8 @@ def test_wrong_storage_backend(monkeypatch):
 
 
 def test_localstorage_backend_missing_required_argument(monkeypatch):
-    monkeypatch.setenv("SETTINGS_FILE", f"{TemporaryDirectory}/settings.ini")
+    tmp = TemporaryDirectory().name
+    monkeypatch.setenv("SETTINGS_FILE", os.path.join(tmp, "settings.ini"))
     monkeypatch.setenv("KAPRIEN_STORAGE_BACKEND", "LocalStorage")
 
     with pytest.raises(AttributeError) as err:
@@ -24,6 +28,10 @@ def test_localstorage_backend_missing_required_argument(monkeypatch):
 
 
 def test_wrong_keyvault_backend(monkeypatch):
+    tmp = TemporaryDirectory().name
+    monkeypatch.setenv("SETTINGS_FILE", os.path.join(tmp, "settings.ini"))
+    monkeypatch.setenv("KAPRIEN_STORAGE_BACKEND", "LocalStorage")
+    monkeypatch.setenv("KAPRIEN_LOCAL_STORAGE_BACKEND_PATH", "metadata")
     monkeypatch.setenv("KAPRIEN_KEYVAULT_BACKEND", "InvalidKeyVault")
 
     with pytest.raises(ValueError) as err:
@@ -33,7 +41,8 @@ def test_wrong_keyvault_backend(monkeypatch):
 
 
 def test_localkeyvault_backend_missing_required_argument(monkeypatch):
-    monkeypatch.setenv("SETTINGS_FILE", f"{TemporaryDirectory}/settings.ini")
+    tmp = TemporaryDirectory().name
+    monkeypatch.setenv("SETTINGS_FILE", os.path.join(tmp, "settings.ini"))
     monkeypatch.setenv("KAPRIEN_STORAGE_BACKEND", "LocalStorage")
     monkeypatch.setenv("KAPRIEN_LOCAL_STORAGE_BACKEND_PATH", "storage/")
     monkeypatch.setenv("KAPRIEN_KEYVAULT_BACKEND", "LocalKeyVault")


### PR DESCRIPTION
This adds to the endpoint /api/v1/targets/ the flow to send the request
to the kaprien-mq to be processed by kaprien-repo-worker.

Closes #43 
Signed-off-by: Kairo de Araujo <kairo@kairo.eti.br>