### PR TITLE
Fix the application name in the celery task

### DIFF
--- a/kaprien_api/__init__.py
+++ b/kaprien_api/__init__.py
@@ -102,6 +102,6 @@ celery.conf.broker_pool_limit = None
 # celery.conf.broker_use_ssl = True
 
 
-@celery.task(name="app.metadata_repository")
+@celery.task(name="app.kaprien_repo_worker")
 def repository_metadata(action, settings, payload):
     return True


### PR DESCRIPTION
Celery task requires exact app name in the worker.

Signed-off-by: Kairo de Araujo <kairo@kairo.eti.br>