### PR TITLE
Fix the serialization for bootstrap

### DIFF
--- a/kaprien_api/bootstrap.py
+++ b/kaprien_api/bootstrap.py
@@ -129,4 +129,6 @@ def post_bootstrap(payload):
         else:
             filename = f"{rolename}.json"
 
-        metadata.to_file(filename, storage_backend=storage)
+        metadata.to_file(
+            filename, tuf.JSONSerializer(), storage_backend=storage
+        )

--- a/kaprien_api/tuf/__init__.py
+++ b/kaprien_api/tuf/__init__.py
@@ -5,6 +5,7 @@ from kaprien_api.tuf.interfaces import IKeyVault, IStorage, ServiceSettings
 from kaprien_api.tuf.repository import (
     TOP_LEVEL_ROLE_NAMES,
     DelegatedRole,
+    JSONSerializer,
     Key,
     Metadata,
     MetadataRepository,
@@ -40,6 +41,7 @@ __all__ = [
     MetadataRepository,
     DelegatedRole,
     TOP_LEVEL_ROLE_NAMES,
+    JSONSerializer,
     MetadataRepository,
     Timestamp,
     Targets.__name__,

--- a/tests/unit/api/test_bootstrap.py
+++ b/tests/unit/api/test_bootstrap.py
@@ -48,6 +48,7 @@ class TestPostBootstrap:
             Metadata=pretend.stub(
                 from_dict=pretend.call_recorder(lambda *a: fake_metadata)
             ),
+            JSONSerializer=pretend.call_recorder(lambda: None),
             Roles=pretend.stub(TIMESTAMP=pretend.stub(value="timestamp")),
         )
         fake_storage = pretend.stub()


### PR DESCRIPTION
Make the files well formatted in the storage using the JSONSerializer.

Signed-off-by: Kairo de Araujo <kairo@kairo.eti.br>