### PR TITLE
Unique tokens

### DIFF
--- a/kaprien_api/token.py
+++ b/kaprien_api/token.py
@@ -8,7 +8,7 @@ from pydantic import ValidationError
 
 from kaprien_api import SCOPES, SECRET_KEY, db
 from kaprien_api.users.crud import get_user_by_username
-from kaprien_api.utils import BaseModel
+from kaprien_api.utils import BaseModel, uuid4
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/v1/token", scopes=SCOPES)
 
@@ -140,7 +140,7 @@ def post(token_data, params):
 
     # return data with requested scopes -- approved :D
     data = {
-        "sub": f"user_{user.id}",
+        "sub": f"user_{user.id}_{uuid4().hex}",
         "username": user.username,
         "password": user.password,
         "scopes": token_data.scopes,

--- a/kaprien_api/utils.py
+++ b/kaprien_api/utils.py
@@ -102,7 +102,8 @@ def save_settings(key: str, value: Any):
 # FIXME: Implement a consistent check (Issue #16)
 def check_metadata():
     try:
-        tuf.Metadata.from_file(filename="1.root", storage_backend=storage)
+        with storage.get("root") as f:
+            f.read()
         return True
     except StorageError:
         return False


### PR DESCRIPTION
Every token now has a unique identifier in the 'sub'

`user_<id>_<uuid>`

Closes #67

Fix bug with checking bootstrap.

Signed-off-by: Kairo de Araujo <kairo@kairo.eti.br>