### PR TITLE
Infrastructure and refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 settings.ini
 metadata/**
 database/*.sqlite
+data_test/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,15 +12,14 @@ ADD requirements.txt /builder/requirements.txt
 
 WORKDIR /builder
 RUN apt-get update && apt-get install libpq-dev gcc -y
-RUN pip install --user -r requirements.txt
 RUN apt-get remove gcc --purge -y \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean autoclean \
     && apt-get autoremove --yes
+RUN pip install --user -r requirements.txt
 
 # Final image
 FROM base_os as pre-final
-RUN apt-get update && apt-get install libpq-dev -y && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /root/.local/bin /usr/local/bin/
 COPY --from=builder /root/.local/lib/python3.10/site-packages /usr/local/lib/python3.10/site-packages/
 
@@ -28,7 +27,7 @@ COPY --from=builder /root/.local/lib/python3.10/site-packages /usr/local/lib/pyt
 FROM pre-final
 
 WORKDIR /opt/kaprien-rest-api
-
+RUN mkdir /data
 COPY app.py /opt/kaprien-rest-api
 COPY kaprien_api /opt/kaprien-rest-api/kaprien_api
 COPY tests /opt/kaprien-rest-api/tests

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,8 @@ build-dev:
 
 run-dev:
 	$(MAKE) build-dev
+	docker login ghcr.io
+	docker pull ghcr.io/kaprien/kaprien-repo-worker:dev
 	docker-compose up --remove-orphans
 
 stop:
@@ -28,9 +30,11 @@ stop:
 clean:
 	$(MAKE) stop
 	docker-compose rm --force
-	rm -rf metadata/*
-	rm -rf keys/*
-	rm -rf database/*.sqlite
+	rm -rf ./metadata/*
+	rm -rf ./keys/*
+	rm -rf ./database/*.sqlite
+	rm -rf ./data
+	rm -rf ./data_test
 
 purge:
 	$(MAKE) clean

--- a/Pipfile
+++ b/Pipfile
@@ -14,7 +14,7 @@ python-multipart = "*"
 python-jose = "*"
 fastapi-users = {extras = ["sqlalchemy"], version = "*"}
 sqlalchemy = "*"
-apscheduler = "*"
+redis = "*"
 
 [dev-packages]
 black = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "2579e6ff4a8b03635ed872e8717772e72af9996e1cc489f858197ddf6d4df437"
+            "sha256": "52808bfd45bc810c36f5fff9568eeac8d5809c2caeb992722067f6e18c8fa5c7"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -32,13 +32,13 @@
             "markers": "python_full_version >= '3.6.2'",
             "version": "==3.6.1"
         },
-        "apscheduler": {
+        "async-timeout": {
             "hashes": [
-                "sha256:65e6574b6395498d371d045f2a8a7e4f7d50c6ad21ef7313d15b1c7cf20df1e3",
-                "sha256:ddc25a0ddd899de44d7f451f4375fb971887e65af51e41e5dcf681f59b8b2c9a"
+                "sha256:2163e1640ddb52b7a8c80d0a67a08587e5d245cc9c553a74a847056bc2976b15",
+                "sha256:8ca1e4fcf50d07413d66d1a5e416e42cfdf5851c981d679a09851a6853383b3c"
             ],
-            "index": "pypi",
-            "version": "==3.9.1"
+            "markers": "python_version >= '3.6'",
+            "version": "==4.0.2"
         },
         "bcrypt": {
             "hashes": [
@@ -221,6 +221,14 @@
             ],
             "version": "==37.0.4"
         },
+        "deprecated": {
+            "hashes": [
+                "sha256:43ac5335da90c31c24ba028af536a91d41d53f9e6901ddb021bcc572ce44e38d",
+                "sha256:64756e3e14c8c5eea9795d93c524551432a0be75629f8f29e67ab8caf076c76d"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.2.13"
+        },
         "dnspython": {
             "hashes": [
                 "sha256:0f7569a4a6ff151958b64304071d370daa3243d15941a7beedf0c9fe5105603e",
@@ -255,11 +263,11 @@
         },
         "fastapi": {
             "hashes": [
-                "sha256:4e542f71b5b0f4f54a82449e8bd0244305de319186a31addab976bf672206420",
-                "sha256:5340f6016860baf94a52be5040c3a2e94c39ddc7ab4cc7548558182db742d9d6"
+                "sha256:9ac5f5d252b4b394df29accb1ed4bedf30e0e87fc6eb7ec75e1449fa040bfc17",
+                "sha256:9dafdc41feda85ee5acf0f7dd6bcb7fd946318a6664b41fd33e33b26f666a346"
             ],
             "index": "pypi",
-            "version": "==0.80.0"
+            "version": "==0.81.0"
         },
         "fastapi-users": {
             "extras": [
@@ -378,6 +386,14 @@
             ],
             "version": "==1.14.0"
         },
+        "packaging": {
+            "hashes": [
+                "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
+                "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==21.3"
+        },
         "passlib": {
             "extras": [
                 "bcrypt"
@@ -473,6 +489,14 @@
             "markers": "python_version >= '3.6'",
             "version": "==2.4.0"
         },
+        "pyparsing": {
+            "hashes": [
+                "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb",
+                "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"
+            ],
+            "markers": "python_full_version >= '3.6.8'",
+            "version": "==3.0.9"
+        },
         "python-jose": {
             "hashes": [
                 "sha256:55779b5e6ad599c6336191246e95eb2293a9ddebd555f796a65f838f07e5d78a",
@@ -495,13 +519,13 @@
             ],
             "version": "==2022.2.1"
         },
-        "pytz-deprecation-shim": {
+        "redis": {
             "hashes": [
-                "sha256:8314c9692a636c8eb3bda879b9f119e350e93223ae83e70e80c31675a0fdc1a6",
-                "sha256:af097bae1b616dde5c5744441e2ddc69e74dfdcb0c263129610d85b87445a59d"
+                "sha256:a52d5694c9eb4292770084fa8c863f79367ca19884b329ab574d5cb2036b3e54",
+                "sha256:ddf27071df4adf3821c4f2ca59d67525c3a82e5f268bed97b813cb4fabf87880"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==0.1.0.post0"
+            "index": "pypi",
+            "version": "==4.3.4"
         },
         "requests": {
             "hashes": [
@@ -518,14 +542,6 @@
             ],
             "markers": "python_version >= '3.6' and python_version < '4'",
             "version": "==4.9"
-        },
-        "setuptools": {
-            "hashes": [
-                "sha256:2e24e0bec025f035a2e72cdd1961119f557d78ad331bb00ff82efb2ab8da8e82",
-                "sha256:7732871f4f7fa58fb6bdcaeadb0161b2bd046c85905dbaa066bdcbcc81953b57"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==65.3.0"
         },
         "six": {
             "hashes": [
@@ -601,22 +617,6 @@
             "markers": "python_version < '3.10'",
             "version": "==4.3.0"
         },
-        "tzdata": {
-            "hashes": [
-                "sha256:21f4f0d7241572efa7f7a4fdabb052e61b55dc48274e6842697ccdf5253e5451",
-                "sha256:c3119520447d68ef3eb8187a55a4f44fa455f30eb1b4238fa5691ba094f2b05b"
-            ],
-            "markers": "python_version >= '3.6'",
-            "version": "==2022.2"
-        },
-        "tzlocal": {
-            "hashes": [
-                "sha256:89885494684c929d9191c57aa27502afc87a579be5cdd3225c77c463ea043745",
-                "sha256:ee5842fa3a795f023514ac2d801c4a81d1743bbe642e3940143326b3a00addd7"
-            ],
-            "markers": "python_version >= '3.6'",
-            "version": "==4.2"
-        },
         "urllib3": {
             "hashes": [
                 "sha256:3fa96cf423e6987997fc326ae8df396db2a8b7c667747d47ddd8ecba91f4a74e",
@@ -647,6 +647,76 @@
                 "sha256:c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83"
             ],
             "version": "==0.2.5"
+        },
+        "wrapt": {
+            "hashes": [
+                "sha256:00b6d4ea20a906c0ca56d84f93065b398ab74b927a7a3dbd470f6fc503f95dc3",
+                "sha256:01c205616a89d09827986bc4e859bcabd64f5a0662a7fe95e0d359424e0e071b",
+                "sha256:02b41b633c6261feff8ddd8d11c711df6842aba629fdd3da10249a53211a72c4",
+                "sha256:07f7a7d0f388028b2df1d916e94bbb40624c59b48ecc6cbc232546706fac74c2",
+                "sha256:11871514607b15cfeb87c547a49bca19fde402f32e2b1c24a632506c0a756656",
+                "sha256:1b376b3f4896e7930f1f772ac4b064ac12598d1c38d04907e696cc4d794b43d3",
+                "sha256:21ac0156c4b089b330b7666db40feee30a5d52634cc4560e1905d6529a3897ff",
+                "sha256:257fd78c513e0fb5cdbe058c27a0624c9884e735bbd131935fd49e9fe719d310",
+                "sha256:2b39d38039a1fdad98c87279b48bc5dce2c0ca0d73483b12cb72aa9609278e8a",
+                "sha256:2cf71233a0ed05ccdabe209c606fe0bac7379fdcf687f39b944420d2a09fdb57",
+                "sha256:2fe803deacd09a233e4762a1adcea5db5d31e6be577a43352936179d14d90069",
+                "sha256:3232822c7d98d23895ccc443bbdf57c7412c5a65996c30442ebe6ed3df335383",
+                "sha256:34aa51c45f28ba7f12accd624225e2b1e5a3a45206aa191f6f9aac931d9d56fe",
+                "sha256:36f582d0c6bc99d5f39cd3ac2a9062e57f3cf606ade29a0a0d6b323462f4dd87",
+                "sha256:380a85cf89e0e69b7cfbe2ea9f765f004ff419f34194018a6827ac0e3edfed4d",
+                "sha256:40e7bc81c9e2b2734ea4bc1aceb8a8f0ceaac7c5299bc5d69e37c44d9081d43b",
+                "sha256:43ca3bbbe97af00f49efb06e352eae40434ca9d915906f77def219b88e85d907",
+                "sha256:4fcc4649dc762cddacd193e6b55bc02edca674067f5f98166d7713b193932b7f",
+                "sha256:5a0f54ce2c092aaf439813735584b9537cad479575a09892b8352fea5e988dc0",
+                "sha256:5a9a0d155deafd9448baff28c08e150d9b24ff010e899311ddd63c45c2445e28",
+                "sha256:5b02d65b9ccf0ef6c34cba6cf5bf2aab1bb2f49c6090bafeecc9cd81ad4ea1c1",
+                "sha256:60db23fa423575eeb65ea430cee741acb7c26a1365d103f7b0f6ec412b893853",
+                "sha256:642c2e7a804fcf18c222e1060df25fc210b9c58db7c91416fb055897fc27e8cc",
+                "sha256:6a9a25751acb379b466ff6be78a315e2b439d4c94c1e99cb7266d40a537995d3",
+                "sha256:6b1a564e6cb69922c7fe3a678b9f9a3c54e72b469875aa8018f18b4d1dd1adf3",
+                "sha256:6d323e1554b3d22cfc03cd3243b5bb815a51f5249fdcbb86fda4bf62bab9e164",
+                "sha256:6e743de5e9c3d1b7185870f480587b75b1cb604832e380d64f9504a0535912d1",
+                "sha256:709fe01086a55cf79d20f741f39325018f4df051ef39fe921b1ebe780a66184c",
+                "sha256:7b7c050ae976e286906dd3f26009e117eb000fb2cf3533398c5ad9ccc86867b1",
+                "sha256:7d2872609603cb35ca513d7404a94d6d608fc13211563571117046c9d2bcc3d7",
+                "sha256:7ef58fb89674095bfc57c4069e95d7a31cfdc0939e2a579882ac7d55aadfd2a1",
+                "sha256:80bb5c256f1415f747011dc3604b59bc1f91c6e7150bd7db03b19170ee06b320",
+                "sha256:81b19725065dcb43df02b37e03278c011a09e49757287dca60c5aecdd5a0b8ed",
+                "sha256:833b58d5d0b7e5b9832869f039203389ac7cbf01765639c7309fd50ef619e0b1",
+                "sha256:88bd7b6bd70a5b6803c1abf6bca012f7ed963e58c68d76ee20b9d751c74a3248",
+                "sha256:8ad85f7f4e20964db4daadcab70b47ab05c7c1cf2a7c1e51087bfaa83831854c",
+                "sha256:8c0ce1e99116d5ab21355d8ebe53d9460366704ea38ae4d9f6933188f327b456",
+                "sha256:8d649d616e5c6a678b26d15ece345354f7c2286acd6db868e65fcc5ff7c24a77",
+                "sha256:903500616422a40a98a5a3c4ff4ed9d0066f3b4c951fa286018ecdf0750194ef",
+                "sha256:9736af4641846491aedb3c3f56b9bc5568d92b0692303b5a305301a95dfd38b1",
+                "sha256:988635d122aaf2bdcef9e795435662bcd65b02f4f4c1ae37fbee7401c440b3a7",
+                "sha256:9cca3c2cdadb362116235fdbd411735de4328c61425b0aa9f872fd76d02c4e86",
+                "sha256:9e0fd32e0148dd5dea6af5fee42beb949098564cc23211a88d799e434255a1f4",
+                "sha256:9f3e6f9e05148ff90002b884fbc2a86bd303ae847e472f44ecc06c2cd2fcdb2d",
+                "sha256:a85d2b46be66a71bedde836d9e41859879cc54a2a04fad1191eb50c2066f6e9d",
+                "sha256:a9a52172be0b5aae932bef82a79ec0a0ce87288c7d132946d645eba03f0ad8a8",
+                "sha256:aa31fdcc33fef9eb2552cbcbfee7773d5a6792c137b359e82879c101e98584c5",
+                "sha256:b014c23646a467558be7da3d6b9fa409b2c567d2110599b7cf9a0c5992b3b471",
+                "sha256:b21bb4c09ffabfa0e85e3a6b623e19b80e7acd709b9f91452b8297ace2a8ab00",
+                "sha256:b5901a312f4d14c59918c221323068fad0540e34324925c8475263841dbdfe68",
+                "sha256:b9b7a708dd92306328117d8c4b62e2194d00c365f18eff11a9b53c6f923b01e3",
+                "sha256:d1967f46ea8f2db647c786e78d8cc7e4313dbd1b0aca360592d8027b8508e24d",
+                "sha256:d52a25136894c63de15a35bc0bdc5adb4b0e173b9c0d07a2be9d3ca64a332735",
+                "sha256:d77c85fedff92cf788face9bfa3ebaa364448ebb1d765302e9af11bf449ca36d",
+                "sha256:d79d7d5dc8a32b7093e81e97dad755127ff77bcc899e845f41bf71747af0c569",
+                "sha256:dbcda74c67263139358f4d188ae5faae95c30929281bc6866d00573783c422b7",
+                "sha256:ddaea91abf8b0d13443f6dac52e89051a5063c7d014710dcb4d4abb2ff811a59",
+                "sha256:dee0ce50c6a2dd9056c20db781e9c1cfd33e77d2d569f5d1d9321c641bb903d5",
+                "sha256:dee60e1de1898bde3b238f18340eec6148986da0455d8ba7848d50470a7a32fb",
+                "sha256:e2f83e18fe2f4c9e7db597e988f72712c0c3676d337d8b101f6758107c42425b",
+                "sha256:e3fb1677c720409d5f671e39bac6c9e0e422584e5f518bfd50aa4cbbea02433f",
+                "sha256:ee2b1b1769f6707a8a445162ea16dddf74285c3964f605877a20e38545c3c462",
+                "sha256:ee6acae74a2b91865910eef5e7de37dc6895ad96fa23603d1d27ea69df545015",
+                "sha256:ef3f72c9666bba2bab70d2a8b79f2c6d2c1a42a7f7e2b0ec83bb2f9e383950af"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==1.14.1"
         }
     },
     "develop": {
@@ -753,10 +823,10 @@
         },
         "distlib": {
             "hashes": [
-                "sha256:a7f75737c70be3b25e2bee06288cec4e4c221de18455b2dd037fe2a795cab2fe",
-                "sha256:b710088c59f06338ca514800ad795a132da19fda270e3ce4affc74abf955a26c"
+                "sha256:14bad2d9b04d3a36127ac97f30b12a19268f211063d8f8ee4f47108896e11b46",
+                "sha256:f35c4b692542ca110de7ef0bea44d73981caeb34ca0b9b6b2e6d7790dda8f80e"
             ],
-            "version": "==0.3.5"
+            "version": "==0.3.6"
         },
         "filelock": {
             "hashes": [

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,14 @@
 version: "3.9"
 
 volumes:
+  kaprien-repo-worker-data:
   kaprien-mq-data:
-  kaprien-rest-api-data:
   kaprien-storage:
   kaprien-keystorage:
-  kaprien-settings:
   kaprien-redis-data:
 
 services:
-  kaprien-mq:
+  rabbitmq:
     image: rabbitmq:3-management-alpine
     container_name: kaprien-mq
     ports:
@@ -19,11 +18,47 @@ services:
      - "kaprien-mq-data:/var/lib/rabbitmq"
      - "kaprien-storage:/var/opt/kaprien/storage"
      - "kaprien-keystorage:/var/opt/kaprien/keystorage"
-     - "kaprien-settings:/var/opt/kaprien/settings/"
     healthcheck:
       test: "exit 0"
     restart: always
     tty: true
+
+  redis:
+    image: redis:4.0
+    volumes:
+      - kaprien-redis-data:/data
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: "exit 0"
+    restart: always
+    tty: true
+
+  kaprien-repo-worker:
+    image: ghcr.io/kaprien/kaprien-repo-worker:dev
+    volumes:
+      - kaprien-repo-worker-data:/data
+    command: "celery -A app worker -B -l debug -Q metadata_repository -n kaprien@dev"
+    environment:
+      - KAPRIEN_STORAGE_BACKEND="LocalStorage"
+      - KAPRIEN_KEYVAULT_BACKEND="LocalKeyVault"
+      - KAPRIEN_LOCAL_STORAGE_BACKEND_PATH="/var/opt/kaprien/storage"
+      - KAPRIEN_LOCAL_KEYVAULT_PATH="/var/opt/kaprien/keystorage"
+      - KAPRIEN_RABBITMQ_SERVER="guest:guest@rabbitmq:5672"
+      - KAPRIEN_REDIS_SERVER="redis://redis"
+      - KAPRIEN_WORKER_ID="dev"
+    healthcheck:
+      test: "exit 0"
+    restart: always
+    tty: true
+
+  web:
+    image: python:3.10-slim-buster
+    command: python -m http.server -d /var/opt/kaprien/storage 8080
+    volumes:
+      - kaprien-storage:/var/opt/kaprien/storage
+    ports:
+      - "8080:8080"
 
   kaprien-rest-api:
     build:
@@ -32,12 +67,17 @@ services:
     ports:
       - 80:8000
     environment:
-      - KAPRIEN_RABBITMQ_SERVER="guest:guest@kaprien-mq:5672"
+      - DATA_DIR=./data
+      - KAPRIEN_RABBITMQ_SERVER="guest:guest@rabbitmq:5672"
+      - KAPRIEN_REDIS_SERVER="redis://redis"
       - SECRETS_KAPRIEN_TOKEN_KEY='secret'
       - SECRETS_KAPRIEN_ADMIN_PASSWORD='secret'
     volumes:
       - ./:/opt/kaprien-rest-api:z
-      - kaprien-settings:/var/opt/kaprien/settings/
     depends_on:
-      kaprien-mq:
+      rabbitmq:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      kaprien-repo-worker:
         condition: service_healthy

--- a/kaprien_api/targets.py
+++ b/kaprien_api/targets.py
@@ -1,7 +1,7 @@
 import json
 from typing import Any, Dict, List, Optional
 
-from kaprien_api import repository_metadata, simple_settings
+from kaprien_api import repository_metadata, settings_repository
 from kaprien_api.utils import BaseModel, get_task_id
 
 
@@ -58,7 +58,7 @@ def post(payload):
     repository_metadata.apply_async(
         kwargs={
             "action": "add_targets",
-            "settings": simple_settings.to_dict(),
+            "settings": settings_repository.to_dict(),
             "payload": payload.dict(by_alias=True),
         },
         task_id=task_id,

--- a/kaprien_api/utils.py
+++ b/kaprien_api/utils.py
@@ -2,11 +2,11 @@ from enum import Enum
 from typing import Any, Dict, List, Literal, Optional
 from uuid import uuid4
 
-from dynaconf import loaders
+from dynaconf import Dynaconf, loaders
 from dynaconf.utils.boxing import DynaBox
 from pydantic import BaseModel, Field
 
-from kaprien_api import SETTINGS_FILE, settings
+from kaprien_api import settings_repository
 
 
 class Roles(Enum):
@@ -98,18 +98,18 @@ class TUFMetadata(BaseModel):
     signed: TUFSigned
 
 
-def save_settings(key: str, value: Any):
+def save_settings(key: str, value: Any, settings: Dynaconf):
     settings.store[key] = value
     settings_data = settings.as_dict(env=settings.current_env)
     loaders.write(
-        SETTINGS_FILE,
+        settings.SETTINGS_FILE_FOR_DYNACONF[0],
         DynaBox(settings_data).to_dict(),
         env=settings.current_env,
     )
 
 
 def is_bootstrap_done():
-    if settings.get("BOOTSTRAP"):
+    if settings_repository.get("BOOTSTRAP"):
         return True
     else:
         return False

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,7 +11,7 @@
 -i https://pypi.org/simple
 amqp==5.1.1; python_version >= '3.6'
 anyio==3.6.1; python_full_version >= '3.6.2'
-apscheduler==3.9.1
+async-timeout==4.0.2; python_version >= '3.6'
 attrs==22.1.0; python_version >= '3.5'
 bcrypt==4.0.0
 billiard==3.6.4.0
@@ -27,14 +27,15 @@ click==8.1.3; python_version >= '3.7'
 configobj==5.0.6
 coverage==6.4.4
 cryptography==37.0.4
-distlib==0.3.5
+deprecated==1.2.13; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+distlib==0.3.6
 dnspython==2.2.1; python_version >= '3.6' and python_version < '4'
 dynaconf==3.1.9
 ecdsa==0.18.0; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'
 email-validator==1.2.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 fastapi-users-db-sqlalchemy==4.0.3
 fastapi-users[sqlalchemy]==10.1.5
-fastapi==0.80.0
+fastapi==0.81.0
 filelock==3.8.0; python_version >= '3.7'
 flake8==5.0.4
 greenlet==1.1.3; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
@@ -65,11 +66,10 @@ pyparsing==3.0.9; python_full_version >= '3.6.8'
 pytest==7.1.2
 python-jose==3.3.0
 python-multipart==0.0.5
-pytz-deprecation-shim==0.1.0.post0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
 pytz==2022.2.1
+redis==4.3.4
 requests==2.28.1; python_version >= '3.7' and python_version < '4'
 rsa==4.9; python_version >= '3.6' and python_version < '4'
-setuptools==65.3.0; python_version >= '3.7'
 six==1.16.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 sniffio==1.2.0; python_version >= '3.5'
 sqlalchemy==1.4.40
@@ -78,10 +78,9 @@ toml==0.10.2; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 
 tomli==2.0.1; python_version >= '3.7'
 tox==3.25.1
 typing-extensions==4.3.0; python_version < '3.10'
-tzdata==2022.2; python_version >= '3.6'
-tzlocal==4.2; python_version >= '3.6'
 urllib3==1.26.12; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' and python_version < '4'
 uvicorn==0.18.3
 vine==5.0.0; python_version >= '3.6'
 virtualenv==20.16.3; python_version >= '3.6'
 wcwidth==0.2.5
+wrapt==1.14.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@
 -i https://pypi.org/simple
 amqp==5.1.1; python_version >= '3.6'
 anyio==3.6.1; python_full_version >= '3.6.2'
-apscheduler==3.9.1
+async-timeout==4.0.2; python_version >= '3.6'
 bcrypt==4.0.0
 billiard==3.6.4.0
 celery==5.2.7
@@ -21,40 +21,41 @@ click-repl==0.2.0
 click==8.1.3; python_version >= '3.7'
 configobj==5.0.6
 cryptography==37.0.4
+deprecated==1.2.13; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 dnspython==2.2.1; python_version >= '3.6' and python_version < '4'
 dynaconf==3.1.9
 ecdsa==0.18.0; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'
 email-validator==1.2.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 fastapi-users-db-sqlalchemy==4.0.3
 fastapi-users[sqlalchemy]==10.1.5
-fastapi==0.80.0
+fastapi==0.81.0
 greenlet==1.1.3; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 h11==0.13.0; python_version >= '3.6'
 hvac==0.11.2
 idna==3.3; python_version >= '3.5'
 kombu==5.2.4; python_version >= '3.7'
 makefun==1.14.0
+packaging==21.3; python_version >= '3.6'
 passlib[bcrypt]==1.7.4
 prompt-toolkit==3.0.30; python_full_version >= '3.6.2'
 pyasn1==0.4.8
 pycparser==2.21
 pydantic==1.9.2; python_full_version >= '3.6.1'
 pyjwt[crypto]==2.4.0; python_version >= '3.6'
+pyparsing==3.0.9; python_full_version >= '3.6.8'
 python-jose==3.3.0
 python-multipart==0.0.5
-pytz-deprecation-shim==0.1.0.post0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
 pytz==2022.2.1
+redis==4.3.4
 requests==2.28.1; python_version >= '3.7' and python_version < '4'
 rsa==4.9; python_version >= '3.6' and python_version < '4'
-setuptools==65.3.0; python_version >= '3.7'
 six==1.16.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 sniffio==1.2.0; python_version >= '3.5'
 sqlalchemy==1.4.40
 starlette==0.19.1; python_version >= '3.6'
 typing-extensions==4.3.0; python_version < '3.10'
-tzdata==2022.2; python_version >= '3.6'
-tzlocal==4.2; python_version >= '3.6'
 urllib3==1.26.12; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' and python_version < '4'
 uvicorn==0.18.3
 vine==5.0.0; python_version >= '3.6'
 wcwidth==0.2.5
+wrapt==1.14.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'

--- a/tests/data_examples/repository_settings/settings.json
+++ b/tests/data_examples/repository_settings/settings.json
@@ -1,29 +1,27 @@
 {
-    "storage_backend": {
-        "type": "LocalStorage",
-        "parameters": {
-            "LOCAL_STORAGE_BACKEND_PATH": {
-                "required": true,
-                "value": "metadata"
-            }
-        }
-    },
-    "keyvault_backend": {
-        "type": "LocalKeyVault",
-        "parameters": {
-            "LOCAL_KEYVAULT_PATH": {
-                "required": true,
-                "value": "keys"
-            }
-        }
-    },
-    "roles_expirations": {
-        "root": "356",
-        "targets": "365",
-        "snapshot": "1",
-        "timestamp": "1",
-        "bin": "365",
-        "bins": "1"
-    },
-    "targets_base_url": "https://www.example.com/downloads/"
+    "targets_base_url": "http://www.example.com/repository/",
+    "bootstrap": "893eb4aec8af499a9f5cc90984ddf3a3",
+    "bins_number_prefixes": "4",
+    "bins_num_keys": "1",
+    "bins_threshold": "1",
+    "bins_expiration": "1",
+    "bin_num_keys": "1",
+    "bin_threshold": "1",
+    "bin_expiration": "365",
+    "timestamp_num_keys": "1",
+    "timestamp_threshold": "1",
+    "timestamp_expiration": "1",
+    "snapshot_num_keys": "1",
+    "snapshot_threshold": "1",
+    "snapshot_expiration": "1",
+    "targets_paths": [
+        "*",
+        "*/*"
+    ],
+    "targets_num_keys": "2",
+    "targets_threshold": "1",
+    "targets_expiration": "365",
+    "root_num_keys": "2",
+    "root_threshold": "1",
+    "root_expiration": "356"
 }

--- a/tests/unit/api/test_bootstrap.py
+++ b/tests/unit/api/test_bootstrap.py
@@ -99,8 +99,10 @@ class TestPostBootstrap:
             "kaprien_api.bootstrap.is_bootstrap_done", mocked_check_metadata
         )
 
+        mocked_async_result = pretend.stub(state="SUCCESS")
         mocked_repository_metadata = pretend.stub(
-            apply_async=pretend.call_recorder(lambda *a, **kw: None)
+            apply_async=pretend.call_recorder(lambda *a, **kw: None),
+            AsyncResult=pretend.call_recorder(lambda *a: mocked_async_result),
         )
         monkeypatch.setattr(
             "kaprien_api.bootstrap.repository_metadata",

--- a/tests/unit/api/test_repository_settings.py
+++ b/tests/unit/api/test_repository_settings.py
@@ -12,53 +12,15 @@ class TestGetSettings:
             mocked_check_metadata,
         )
 
-        def fake_get(arg):
-            if "_EXPIRATION" in arg:
-                return 30
-            else:
-                return "fake_value"
-
-        fake_backend = pretend.stub(
-            name="FakeBackend",
-            required=True,
-        )
         fake_settings = pretend.stub(
-            STORAGE_BACKEND=pretend.stub(
-                __name__="fake_storage_backend",
-                settings=pretend.call_recorder(lambda: [fake_backend]),
-            ),
-            KEYVAULT_BACKEND=pretend.stub(
-                __name__="fake_keyvault_backend",
-                settings=pretend.call_recorder(lambda: [fake_backend]),
-            ),
-            get=pretend.call_recorder(fake_get),
+            to_dict=pretend.call_recorder(
+                lambda: {"k": "v", "j": ["v1", "v2"]}
+            )
         )
-        monkeypatch.setattr(
-            "kaprien_api.repository_settings.settings", fake_settings
-        )
+        monkeypatch.setattr("kaprien_api.repository_settings", fake_settings)
 
         test_response = test_client.get(url, headers=token_headers)
         assert test_response.status_code == status.HTTP_200_OK
-        assert sorted(list(test_response.json()["data"].keys())) == [
-            "keyvault_backend",
-            "roles_expirations",
-            "storage_backend",
-        ]
-        assert test_response.json()["message"] == "Current Settings"
-        assert fake_settings.STORAGE_BACKEND.settings.calls == [pretend.call()]
-        assert fake_settings.KEYVAULT_BACKEND.settings.calls == [
-            pretend.call()
-        ]
-        assert fake_settings.get.calls == [
-            pretend.call("FakeBackend"),
-            pretend.call("FakeBackend"),
-            pretend.call("root_EXPIRATION"),
-            pretend.call("targets_EXPIRATION"),
-            pretend.call("snapshot_EXPIRATION"),
-            pretend.call("timestamp_EXPIRATION"),
-            pretend.call("bin_EXPIRATION"),
-            pretend.call("bins_EXPIRATION"),
-        ]
 
     def test_get_settings_without_bootstrap(
         self, test_client, token_headers, monkeypatch
@@ -109,7 +71,8 @@ class TestGetSettings:
             get=pretend.call_recorder(fake_get),
         )
         monkeypatch.setattr(
-            "kaprien_api.repository_settings.settings", fake_settings
+            "kaprien_api.repository_settings.settings_repository",
+            fake_settings,
         )
         token_headers = {"Authorization": "Bearer h4ck3r"}
 

--- a/tests/unit/api/test_targets.py
+++ b/tests/unit/api/test_targets.py
@@ -7,7 +7,7 @@ from fastapi import status
 
 class TestPostTargets:
     def test_post(self, monkeypatch, test_client, token_headers):
-        from kaprien_api import simple_settings  # noqa
+        from kaprien_api import settings_repository  # noqa
 
         url = "/api/v1/targets/"
         with open("tests/data_examples/targets/payload.json") as f:
@@ -38,7 +38,7 @@ class TestPostTargets:
             pretend.call(
                 kwargs={
                     "action": "add_targets",
-                    "settings": simple_settings.to_dict(),
+                    "settings": settings_repository.to_dict(),
                     "payload": payload,
                 },
                 task_id=fake_task_id,

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -7,6 +7,7 @@ from fastapi.testclient import TestClient
 
 @pytest.fixture()
 def test_client(monkeypatch):
+    monkeypatch.setenv("DATA_DIR", "./data_test")
     monkeypatch.setenv("SECRETS_KAPRIEN_TOKEN_KEY", "secret")
     monkeypatch.setenv("SECRETS_KAPRIEN_ADMIN_PASSWORD", "secret")
     monkeypatch.setenv("KAPRIEN_STORAGE_BACKEND", "LocalStorage")


### PR DESCRIPTION
- Segregated settings for repository and the service, settings for
  repository can be distribuited to the repository workers
  Closes #78

- Removed APScheduler as the scheduled tasks were moved to
  kaprien-repo-worker
  Closes #79

- Beside the bootstrap is executed by repository worker, it is like
  'synchronous' in the kaprien-rest-api

- Fixed the settings to have better consistence in the data
  Closes #63

Improved the expirence for development
- Added redis and kaprien-repo-worker to the make run-dev
  Closes #47

Signed-off-by: Kairo de Araujo <kairo@kairo.eti.br>