### PR TITLE
But to request a token for write targets

### DIFF
--- a/kaprien_api/token.py
+++ b/kaprien_api/token.py
@@ -85,7 +85,7 @@ class TokenRequestPayload(BaseModel):
             SCOPES_NAMES.read_settings.value,
             SCOPES_NAMES.read_targets.value,
             SCOPES_NAMES.read_token.value,
-            SCOPES_NAMES.write_targets,
+            SCOPES_NAMES.write_targets.value,
         ]
     ]
     expires: int = Field(description="In hour(s)")


### PR DESCRIPTION
Not possible to add token with add targets (write targest).
But is the Literal was missing the string for the scope

Signed-off-by: Kairo de Araujo <kairo@kairo.eti.br>