### PR TITLE
Remove the AsyncResult check

### DIFF
--- a/kaprien_api/bootstrap.py
+++ b/kaprien_api/bootstrap.py
@@ -2,7 +2,6 @@ import json
 import logging
 from typing import Dict, List, Literal, Optional
 
-from celery import states as celery_state
 from fastapi import HTTPException, status
 
 from kaprien_api import repository_metadata, settings_repository


### PR DESCRIPTION
Rolback the AsyncRsult during bootstrap, it will be better designed in
the future using a unique point to get task status and becoming an
option for run bootstrap 'synchronous'.

Signed-off-by: Kairo de Araujo <kairo@kairo.eti.br>