### PR TITLE
Fix wrong scope summary for POST v1/api/targets

### DIFF
--- a/kaprien_api/api/targets.py
+++ b/kaprien_api/api/targets.py
@@ -14,7 +14,7 @@ router = APIRouter(
     "/",
     summary=(
         "Add targets files to Metadata. "
-        f"Scope: {SCOPES_NAMES.write_bootstrap.value}"
+        f"Scope: {SCOPES_NAMES.write_targets.value}"
     ),
     description="Add targets files to Metadata.",
     response_model=targets.Response,


### PR DESCRIPTION
Besides the scope is correct in the Security, there is wrong information in the endpoint summary

Signed-off-by: Kairo de Araujo <kairo@kairo.eti.br>