### PR TITLE
Rename REDIS_SERVER to RESULT_BACKEND_SERVER

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       - KAPRIEN_LOCAL_STORAGE_BACKEND_PATH="/var/opt/kaprien/storage"
       - KAPRIEN_LOCAL_KEYVAULT_PATH="/var/opt/kaprien/keystorage"
       - KAPRIEN_RABBITMQ_SERVER="guest:guest@rabbitmq:5672"
-      - KAPRIEN_REDIS_SERVER="redis://redis"
+      - KAPRIEN_RESULT_BACKEND_SERVER="redis://redis"
       - KAPRIEN_WORKER_ID="dev"
     healthcheck:
       test: "exit 0"
@@ -69,7 +69,7 @@ services:
     environment:
       - DATA_DIR=./data
       - KAPRIEN_BROKER_SERVER="amqp://guest:guest@rabbitmq:5672"
-      - KAPRIEN_REDIS_SERVER="redis://redis"
+      - KAPRIEN_RESULT_BACKEND_SERVER="redis://redis"
       - SECRETS_KAPRIEN_TOKEN_KEY="secret"
       - SECRETS_KAPRIEN_ADMIN_PASSWORD="secret"
     volumes:

--- a/docs/diagrams/kaprien-rest-api-C1.puml
+++ b/docs/diagrams/kaprien-rest-api-C1.puml
@@ -8,7 +8,7 @@ AddRelTag("download", $textColor="orange", $lineColor="Blue")
 Person(user, "API User")  #Grey
 
 System(kaprien, "KAPRIEN-REST-API", "Signed Metadata")
-System(queue, "Broker", "Redis, RabbitMQ, etc") #Grey
+System(queue, "Broker/Backend", "Redis, RabbitMQ, etc") #Grey
 
 Rel_D(user, kaprien, "HTTP Requests")
 Rel_D(kaprien, queue, "Publisher, Backend")

--- a/docs/source/guide/Docker_README.md
+++ b/docs/source/guide/Docker_README.md
@@ -16,9 +16,9 @@ In order to run this container you'll need docker installed.
 Some required services:
 
 * kaprien-repo-worker
-* Compatible Borker Service with [Celery](http://docs.celeryq.dev/),
-  recommended [RabbitMQ](https://www.rabbitmq.com) or
-  [Redis](https://redis.com)
+* Compatible Borker and Result Backend Service with
+  [Celery](https://docs.celeryq.dev/en/stable/getting-started/backends-and-brokers/index.html).
+  Recomended: [RabbitMQ](https://www.rabbitmq.com) or [Redis](https://redis.com)
 
 
 ## Usage
@@ -27,7 +27,7 @@ Some required services:
 
 ```shell
 docker run --env="KAPRIEN_BROKER_SERVER=amqp://guest:guest@rabbitmq:5672" \
-    --env="KAPRIEN_REDIS_SERVER=redis://redis" \
+    --env="KAPRIEN_RESULT_BACKEND_SERVER=redis://redis" \
     --env="SECRETS_KAPRIEN_TOKEN_KEY=secret" \
     --env="SECRETS_KAPRIEN_ADMIN_PASSWORD=password" \
     ghcr.io/kaprien/kaprien-repo-worker:latest \
@@ -45,20 +45,22 @@ The broker must to be compatible with Celery. See [Celery Broker Instructions](h
 
 Example: `amqp://guest:guest@rabbitmq:5672`
 
-#### (Required) `KAPRIEN_REDIS_SERVER`
+#### (Required) `KAPRIEN_RESULT_BACKEND_SERVER`
 
-Description: Redis server address.
+Redis server address.
+
+The result backend must to be compatible with Celery. See
+[Celery Task result backend settings](https://docs.celeryq.dev/en/stable/userguide/configuration.html#task-result-backend-settings)
 
 Example: `redis://redis`
 
 #### (Required) `SECRETS_KAPRIEN_TOKEN_KEY`
 
-Secret Token to hash the Tokens.
-
+Secret Token for hash the Tokens.
 
 #### (Required) `SECRETS_KAPRIEN_ADMIN_PASSWORD`
 
-Secret admin password. This is required.
+Secret admin password.
 
 #### (Optional) `DATA_DIR`
 

--- a/kaprien_api/__init__.py
+++ b/kaprien_api/__init__.py
@@ -101,7 +101,7 @@ if not user:
 
 celery = Celery(__name__)
 celery.conf.broker_url = settings.BROKER_SERVER
-celery.conf.result_backend = settings.REDIS_SERVER
+celery.conf.result_backend = settings.RESULT_BACKEND_SERVER
 celery.conf.accept_content = ["json", "application/json"]
 celery.conf.task_serializer = "json"
 celery.conf.result_serializer = "json"

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ setenv =
     SECRETS_KAPRIEN_ADMIN_PASSWORD = "secret"
     DATA_DIR = ./data_test
     KAPRIEN_BROKER_SERVER = "fakeserver"
-    KAPRIEN_REDIS_SERVER = "fakeserver"
+    KAPRIEN_RESULT_BACKEND_SERVER = "fakeserver"
 
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/requirements-dev.txt


### PR DESCRIPTION
This gives more flexibility during deployment, making clear that the Result Backend must be compatible with Celery.

This complements the Pull Request #93

Signed-off-by: Kairo Araujo <kairo@kairo.eti.br>