### PR TITLE
Add endpoint to retrieve the task status

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, FastAPI
 from kaprien_api.api.bootstrap import router as bootstrap_v1
 from kaprien_api.api.config import router as config_v1
 from kaprien_api.api.targets import router as targets_v1
+from kaprien_api.api.tasks import router as tasks_v1
 from kaprien_api.api.token import router as token_v1
 
 logging.basicConfig(
@@ -36,6 +37,7 @@ api_v1.include_router(bootstrap_v1)
 api_v1.include_router(config_v1)
 api_v1.include_router(targets_v1)
 api_v1.include_router(token_v1)
+api_v1.include_router(tasks_v1)
 
 kaprien_app.include_router(api_v1)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,8 @@ services:
     tty: true
 
   kaprien-repo-worker:
-    image: ghcr.io/kaprien/kaprien-repo-worker:dev
+    #image: ghcr.io/kaprien/kaprien-repo-worker:dev
+    image: kaprien-repo-worker:dev
     volumes:
       - kaprien-repo-worker-data:/data
     command: "celery -A app worker -B -l debug -Q metadata_repository -n kaprien@dev"
@@ -44,7 +45,7 @@ services:
       - KAPRIEN_KEYVAULT_BACKEND="LocalKeyVault"
       - KAPRIEN_LOCAL_STORAGE_BACKEND_PATH="/var/opt/kaprien/storage"
       - KAPRIEN_LOCAL_KEYVAULT_PATH="/var/opt/kaprien/keystorage"
-      - KAPRIEN_RABBITMQ_SERVER="guest:guest@rabbitmq:5672"
+      - KAPRIEN_BROKER_SERVER="amqp://guest:guest@rabbitmq:5672"
       - KAPRIEN_RESULT_BACKEND_SERVER="redis://redis"
       - KAPRIEN_WORKER_ID="dev"
     healthcheck:

--- a/docs/diagrams/kaprien-rest-api-C3.puml
+++ b/docs/diagrams/kaprien-rest-api-C3.puml
@@ -46,6 +46,7 @@ System_Boundary(kaprien_rest_api, "KAPRIEN-REST-API") #APPLICATION {
             Container(api_config, "config")
             Container(api_bootstrap, "bootstrap")
             Container(api_targets, "targets")
+            Container(api_tasks, "tasks")
             Container(api_token, "token")
         }
         Container_Boundary(users, "users", SQL) #LightBlue {
@@ -58,6 +59,7 @@ System_Boundary(kaprien_rest_api, "KAPRIEN-REST-API") #APPLICATION {
         Container(bootstrap, "bootstrap")
         Container(targets, "targets")
         Container(token, "token")
+        Container(tasks, "tasks")
         Container(metadata, "metadata")
 
         Container_Ext(celery, "Celery()")
@@ -78,9 +80,11 @@ Rel(api_bootstrap, bootstrap, " ")
 Rel(api_config, config, " ")
 Rel(api_targets, targets, " ")
 Rel(api_token, token, " ")
+Rel(api_tasks, tasks, " ")
 Rel(fast_api_authentication, token, "O2Auth")
 Rel(targets, metadata, " ")
 Rel(bootstrap, metadata, " ")
+Rel(tasks, metadata, " ")
 Rel(targets, config, " ")
 Rel(bootstrap, config, " ")
 Rel(metadata, celery, " ")
@@ -98,5 +102,6 @@ Lay_R(token, bootstrap)
 Lay_R(bootstrap, targets)
 Lay_R(sqlalchemy, dynaconf)
 Lay_R(dynaconf, celery)
+
 HIDE_STEREOTYPE()
 @enduml

--- a/docs/source/devel/kaprien_api.api.rst
+++ b/docs/source/devel/kaprien_api.api.rst
@@ -28,6 +28,14 @@ kaprien\_api.api.targets module
    :undoc-members:
    :show-inheritance:
 
+kaprien\_api.api.tasks module
+-----------------------------
+
+.. automodule:: kaprien_api.api.tasks
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 kaprien\_api.api.token module
 -----------------------------
 

--- a/docs/source/devel/kaprien_api.rst
+++ b/docs/source/devel/kaprien_api.rst
@@ -45,6 +45,14 @@ kaprien\_api.targets module
    :undoc-members:
    :show-inheritance:
 
+kaprien\_api.tasks module
+-------------------------
+
+.. automodule:: kaprien_api.tasks
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 kaprien\_api.token module
 -------------------------
 

--- a/docs/source/guide/api/swagger.json
+++ b/docs/source/guide/api/swagger.json
@@ -329,6 +329,63 @@
                     }
                 ]
             }
+        },
+        "/api/v1/task/": {
+            "get": {
+                "tags": [
+                    "v1",
+                    "v1"
+                ],
+                "summary": "Get task status. Scope: read:tasks",
+                "description": "Get Repository Metadata task status. The status is according with Celery tasks: `PENDING` the task still not processed or unknown/inexistent task. `RECEIVED` task is reveived by the broker server. `PRE_RUN` the task will start by kaprien-repo-worker. `RUNNING` the task is in execution. `FAILURE` the task failed to executed. `SUCCESS` the task execution is finished.",
+                "operationId": "get_api_v1_task__get",
+                "security": [
+                    {
+                        "OAuth2PasswordBearer": [
+                            "read:tasks"
+                        ]
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "task_id",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "title": "Task Id",
+                            "description": "Task id",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "description": "Task id"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/kaprien_api__tasks__Response"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     },
     "components": {
@@ -352,7 +409,7 @@
                     "scope": {
                         "title": "Scope",
                         "type": "string",
-                        "description": "Add scopes separeted by space. Default user scopes. Users might not have all scopes. Available scopes: read:bootstrap read:settings read:targets read:token write:bootstrap write:targets write:token",
+                        "description": "Add scopes separeted by space. Default user scopes. Users might not have all scopes. Available scopes: read:bootstrap read:settings read:targets read:tasks read:token write:bootstrap write:targets write:token",
                         "default": ""
                     },
                     "expires": {
@@ -1165,6 +1222,7 @@
                             "read:bootstrap",
                             "read:settings",
                             "read:targets",
+                            "read:tasks",
                             "read:token",
                             "write:bootstrap",
                             "write:targets",
@@ -1722,6 +1780,30 @@
                     }
                 }
             },
+            "TasksData": {
+                "title": "TasksData",
+                "required": [
+                    "task_id",
+                    "status"
+                ],
+                "type": "object",
+                "properties": {
+                    "task_id": {
+                        "title": "Task Id",
+                        "type": "string",
+                        "description": "Task ID"
+                    },
+                    "status": {
+                        "title": "Status",
+                        "type": "string",
+                        "description": "Status according with Celery Tasks"
+                    },
+                    "result": {
+                        "title": "Result",
+                        "description": "Details about the task execution."
+                    }
+                }
+            },
             "TokenPublicData": {
                 "title": "TokenPublicData",
                 "required": [
@@ -1886,6 +1968,34 @@
                     },
                     "message": "Target(s) successfully submitted."
                 }
+            },
+            "kaprien_api__tasks__Response": {
+                "title": "Response",
+                "required": [
+                    "data"
+                ],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/TasksData"
+                    },
+                    "message": {
+                        "title": "Message",
+                        "type": "string"
+                    }
+                },
+                "example": {
+                    "data": {
+                        "tasks": [
+                            {
+                                "task_id": "91353735ef7d48099df86d8bfa30316e",
+                                "status": "SUCCESS",
+                                "result": true
+                            }
+                        ],
+                        "message": "Task details. "
+                    }
+                }
             }
         },
         "securitySchemes": {
@@ -1897,6 +2007,7 @@
                             "read:targets": "Read (GET) targets",
                             "read:bootstrap": "Read (GET) bootstrap",
                             "read:settings": "Read (GET) settings",
+                            "read:tasks": "Read (GET) tasks",
                             "read:token": "Read (GET) tokens",
                             "write:targets": "Write (POST) targets",
                             "write:token": "Write (POST) token",

--- a/kaprien_api/__init__.py
+++ b/kaprien_api/__init__.py
@@ -15,6 +15,7 @@ class SCOPES_NAMES(Enum):
     read_bootstrap = "read:bootstrap"
     read_settings = "read:settings"
     read_targets = "read:targets"
+    read_tasks = "read:tasks"
     read_token = "read:token"
     write_bootstrap = "write:bootstrap"
     write_targets = "write:targets"
@@ -25,6 +26,7 @@ SCOPES = {
     SCOPES_NAMES.read_targets.value: "Read (GET) targets",
     SCOPES_NAMES.read_bootstrap.value: "Read (GET) bootstrap",
     SCOPES_NAMES.read_settings.value: "Read (GET) settings",
+    SCOPES_NAMES.read_tasks.value: "Read (GET) tasks",
     SCOPES_NAMES.read_token.value: "Read (GET) tokens",
     SCOPES_NAMES.write_targets.value: "Write (POST) targets",
     SCOPES_NAMES.write_token.value: "Write (POST) token",

--- a/kaprien_api/api/tasks.py
+++ b/kaprien_api/api/tasks.py
@@ -1,0 +1,33 @@
+from fastapi import APIRouter, Depends, Security
+
+from kaprien_api import SCOPES_NAMES, tasks
+from kaprien_api.token import validate_token
+
+router = APIRouter(
+    prefix="/task",
+    tags=["v1"],
+    responses={404: {"description": "Not found"}},
+)
+
+
+@router.get(
+    "/",
+    summary=("Get task status. " f"Scope: {SCOPES_NAMES.read_tasks.value}"),
+    description=(
+        "Get Repository Metadata task status. "
+        "The status is according with Celery tasks: "
+        "`PENDING` the task still not processed or unknown/inexistent task. "
+        "`RECEIVED` task is reveived by the broker server. "
+        "`PRE_RUN` the task will start by kaprien-repo-worker. "
+        "`RUNNING` the task is in execution. "
+        "`FAILURE` the task failed to executed. "
+        "`SUCCESS` the task execution is finished. "
+    ),
+    response_model=tasks.Response,
+    response_model_exclude_none=True,
+)
+def get(
+    params: tasks.GetParameters = Depends(),
+    _user=Security(validate_token, scopes=[SCOPES_NAMES.read_tasks.value]),
+):
+    return tasks.get(params.task_id)

--- a/kaprien_api/tasks.py
+++ b/kaprien_api/tasks.py
@@ -1,0 +1,72 @@
+from typing import Any, Optional
+
+from fastapi import Query
+from pydantic import BaseModel, Field
+
+from kaprien_api.metadata import repository_metadata
+
+
+class GetParameters:
+    def __init__(
+        self,
+        task_id: str = Query(description="Task id", required=True),
+    ):
+        self.task_id = task_id
+
+
+class TasksData(BaseModel):
+    task_id: str = Field(description="Task ID")
+    status: str = Field(
+        description="Status according with Celery Tasks",
+    )
+    result: Optional[Any] = Field(
+        description="Details about the task execution.",
+    )
+
+
+class Response(BaseModel):
+    data: TasksData
+    message: Optional[str]
+
+    class Config:
+        data_example = {
+            "data": {
+                "tasks": [
+                    {
+                        "task_id": "91353735ef7d48099df86d8bfa30316e",
+                        "status": "SUCCESS",
+                        "result": True,
+                    }
+                ],
+                "message": "Task details. ",
+            }
+        }
+        schema_extra = {"example": data_example}
+
+
+def get(task_id: str) -> Response:
+    """
+    Get the task details from Result Backend Server.
+
+    Uses the Celery implementation in
+    ``kaprien_api.metadata.metadata_repository.AsyncResult`` to fetch from
+    Result Backend the task status.
+
+    Args:
+        task_id: Task ID
+
+    Returns:
+        ``Response`` as BaseModel from pydantic
+    """
+    task = repository_metadata.AsyncResult(task_id)
+    if isinstance(task.result, Exception):
+        task_result = str(task.result)
+    else:
+        task_result = task.result
+
+    return Response(
+        data=TasksData(
+            task_id=task_id, status=task.status, result=task_result
+        ),
+        message="Task status.",
+    )

--- a/tests/unit/api/test_tasks.py
+++ b/tests/unit/api/test_tasks.py
@@ -1,0 +1,85 @@
+import pretend
+from fastapi import status
+
+
+class TestGetTask:
+    def test_get(self, test_client, token_headers, monkeypatch):
+        url = "/api/v1/task/"
+
+        mocked_task_result = pretend.stub(status="SUCCESS", result=True)
+        mocked_repository_metadata = pretend.stub(
+            AsyncResult=pretend.call_recorder(lambda t: mocked_task_result)
+        )
+        monkeypatch.setattr(
+            "kaprien_api.tasks.repository_metadata",
+            mocked_repository_metadata,
+        )
+
+        test_response = test_client.get(
+            f"{url}?task_id=test_id", headers=token_headers
+        )
+        assert test_response.status_code == status.HTTP_200_OK
+        assert test_response.json() == {
+            "data": {
+                "task_id": "test_id",
+                "status": "SUCCESS",
+                "result": True,
+            },
+            "message": "Task status.",
+        }
+        assert mocked_repository_metadata.AsyncResult.calls == [
+            pretend.call("test_id")
+        ]
+
+    def test_get_result_is_exception(
+        self, test_client, token_headers, monkeypatch
+    ):
+        url = "/api/v1/task/"
+
+        mocked_task_result = pretend.stub(
+            status="SUCCESS", result=ValueError("Failed to load")
+        )
+        mocked_repository_metadata = pretend.stub(
+            AsyncResult=pretend.call_recorder(lambda t: mocked_task_result)
+        )
+        monkeypatch.setattr(
+            "kaprien_api.tasks.repository_metadata",
+            mocked_repository_metadata,
+        )
+
+        test_response = test_client.get(
+            f"{url}?task_id=test_id", headers=token_headers
+        )
+        assert test_response.status_code == status.HTTP_200_OK
+        assert test_response.json() == {
+            "data": {
+                "task_id": "test_id",
+                "status": "SUCCESS",
+                "result": "Failed to load",
+            },
+            "message": "Task status.",
+        }
+        assert mocked_repository_metadata.AsyncResult.calls == [
+            pretend.call("test_id")
+        ]
+
+    def test_get_invalid_scope(self, test_client, monkeypatch):
+        url = "/api/v1/task/"
+        token_url = "/api/v1/token/?expires=1"
+        token_payload = {
+            "username": "admin",
+            "password": "secret",
+            "scope": ("read:targets " "read:settings " "read:token "),
+        }
+        token = test_client.post(token_url, data=token_payload)
+        headers = {
+            "Authorization": f"Bearer {token.json()['access_token']}",
+        }
+
+        test_response = test_client.get(
+            f"{url}?task_id=test_id", headers=headers
+        )
+        assert test_response.status_code == status.HTTP_403_FORBIDDEN
+        assert test_response.json() == {
+            "detail": {"error": "scope 'read:tasks' not allowed"}
+        }

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -33,6 +33,7 @@ def token_headers(test_client):
             "read:bootstrap "
             "read:settings "
             "read:token "
+            "read:tasks "
         ),
     }
     token = test_client.post(token_url, data=token_payload)

--- a/tox.ini
+++ b/tox.ini
@@ -37,9 +37,11 @@ commands_post =
 
 [testenv:docs]
 deps = -r{toxinidir}/docs/requirements.txt
+allowlist_externals =
+    rm
 commands =
     python -c "import app; app.export_swagger_json('docs/source/guide/api/swagger.json')"
-	sphinx-apidoc -o  docs/source/devel/ kaprien_api
+	sphinx-apidoc -f -o  docs/source/devel/ kaprien_api
 	sphinx-build -E -W -b html docs/source docs/build/html
 
 [testenv:test]


### PR DESCRIPTION
This endpoint can be used internally and externally by third part to check if a task was finished, for example, to make a release public only after the task finished.

Closes #72

Requires merged before:
 - https://github.com/kaprien/kaprien-repo-worker/issues/33

Signed-off-by: Kairo Araujo <kairo@kairo.eti.br>