### PR TITLE
Add support for SSL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,4 @@ RUN mkdir /data
 COPY app.py /opt/kaprien-rest-api
 COPY kaprien_api /opt/kaprien-rest-api/kaprien_api
 COPY tests /opt/kaprien-rest-api/tests
-ENTRYPOINT ["uvicorn", "app:kaprien_app", "--host", "0.0.0.0", "--port", "80"]
+ENTRYPOINT ["bash", "entrypoint.sh"]

--- a/docs/source/guide/Docker_README.md
+++ b/docs/source/guide/Docker_README.md
@@ -31,8 +31,8 @@ docker run --env="KAPRIEN_BROKER_SERVER=amqp://guest:guest@rabbitmq:5672" \
     --env="KAPRIEN_REDIS_SERVER=redis://redis" \
     --env="SECRETS_KAPRIEN_TOKEN_KEY=secret" \
     --env="SECRETS_KAPRIEN_ADMIN_PASSWORD=password" \
+    --port 80:80
     ghcr.io/kaprien/kaprien-repo-worker:latest \
-    uvicorn app:kaprien_app --host 0.0.0.0 --port 8000 --reload
 ```
 
 
@@ -87,6 +87,16 @@ Secret Token for hash the Tokens.
 
 Secret admin password.
 
+
+#### (Optional) `SECRETS_KAPRIEN_SSL_CERT`
+
+SSL Certificate file. Example ``/path/to/api.crt``
+
+Conainer running port will be 443
+
+Requires a another environment variable ``SECRETS_KAPRIEN_SSL_KEY`` with the
+certificate key file. Example ``/path/to/api.key``
+
 #### (Optional) `DATA_DIR`
 
 Data Directory. Default: `/data/`.
@@ -94,3 +104,10 @@ Data Directory. Default: `/data/`.
 ### Volumes
 
 * `/data` - File location
+
+
+### Ports
+
+Default port 80
+
+If using ``SECRETS_KAPRIEN_SSL_CERT``, port 443

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+
+if [[ -z ${SECRETS_KAPRIEN_SSL_CERT} ]]; then
+    echo "uvicorn app:kaprien_app --host 0.0.0.0 --port 80"
+else
+    if [[ -z ${SECRETS_KAPRIEN_SSL_KEY} ]]; then
+        echo "Missing variable SECRETS_KAPRIEN_SSL_KEY"
+        exit 1
+    fi
+    echo "uvicorn app:kaprien_app --host 0.0.0.0 --port 443 --ssl-keyfile ${SECRETS_KAPRIEN_SSL_KEY} --ssl-certfile ${SECRETS_KAPRIEN_SSL_CERT}"
+fi


### PR DESCRIPTION
This commit add the support on ``kaprien-rest-api`` to serve the Rest API using HTTPS.

Linked to:
- https://github.com/kaprien/kaprien/issues/6

Signed-off-by: Kairo Araujo <kairo@kairo.eti.br>