### PR TITLE
Add method to delete targets

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,23 +3,12 @@ import logging
 
 from fastapi import APIRouter, FastAPI
 
-from kaprien_api import settings
+from kaprien_api import settings, settings_repository
 from kaprien_api.api.bootstrap import router as bootstrap_v1
 from kaprien_api.api.config import router as config_v1
 from kaprien_api.api.targets import router as targets_v1
 from kaprien_api.api.tasks import router as tasks_v1
 from kaprien_api.api.token import router as token_v1
-
-logging.basicConfig(
-    level=logging.DEBUG,
-    format="%(asctime)s %(levelname)s %(message)s",
-    datefmt="%H:%M:%S",
-)
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s %(levelname)s %(message)s",
-    datefmt="%H:%M:%S",
-)
 
 kaprien_app = FastAPI(
     title="Kaprien Rest API",
@@ -34,8 +23,9 @@ api_v1 = APIRouter(
 )
 
 if settings.get("BOOTSTRAP_NODE", False) is True:
-    logging.info(settings.BOOTSTRAP_NODE)
     api_v1.include_router(bootstrap_v1)
+logging.info(f"Bootstrap on this node enabled: {settings.BOOTSTRAP_NODE}")
+logging.info(f"Bootstrap ID: {settings_repository.get_fresh('BOOTSTRAP')}")
 
 api_v1.include_router(config_v1)
 api_v1.include_router(targets_v1)

--- a/docs/source/guide/api/swagger.json
+++ b/docs/source/guide/api/swagger.json
@@ -136,7 +136,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/Payload"
+                                "$ref": "#/components/schemas/AddPayload"
                             }
                         }
                     },
@@ -171,6 +171,57 @@
                     {
                         "OAuth2PasswordBearer": [
                             "write:targets"
+                        ]
+                    }
+                ]
+            },
+            "delete": {
+                "tags": [
+                    "v1",
+                    "v1"
+                ],
+                "summary": "Remove targets files from Metadata. Scope: delete:targets",
+                "description": "Remove targets files from Metadata.",
+                "operationId": "delete_api_v1_targets__delete",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/DeletePayload"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "202": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/kaprien_api__targets__Response"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "OAuth2PasswordBearer": [
+                            "delete:targets"
                         ]
                     }
                 ]
@@ -390,6 +441,51 @@
     },
     "components": {
         "schemas": {
+            "AddPayload": {
+                "title": "AddPayload",
+                "required": [
+                    "targets"
+                ],
+                "type": "object",
+                "properties": {
+                    "targets": {
+                        "title": "Targets",
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Targets"
+                        }
+                    }
+                },
+                "description": "POST method required Payload.",
+                "example": {
+                    "targets": [
+                        {
+                            "info": {
+                                "length": 11342,
+                                "hashes": {
+                                    "blake2b-256": "716f6e863f744b9ac22c97ec7b76ea5f5908bc5b2f67c61510bfc4751384ea7a"
+                                },
+                                "custom": {
+                                    "key": "value"
+                                }
+                            },
+                            "path": "file1.tar.gz"
+                        },
+                        {
+                            "info": {
+                                "length": 630,
+                                "hashes": {
+                                    "blake2b-256": "69217a3079908094e11121d042354a7c1f55b6482ca1a51e1b250dfd1ed0eef9"
+                                },
+                                "custom": {
+                                    "key": "value"
+                                }
+                            },
+                            "path": "file2.tar.gz"
+                        }
+                    ]
+                }
+            },
             "Body_post_api_v1_token__post": {
                 "title": "Body_post_api_v1_token__post",
                 "required": [
@@ -409,7 +505,7 @@
                     "scope": {
                         "title": "Scope",
                         "type": "string",
-                        "description": "Add scopes separeted by space. Default user scopes. Users might not have all scopes. Available scopes: read:bootstrap read:settings read:targets read:tasks read:token write:bootstrap write:targets write:token",
+                        "description": "Add scopes separeted by space. Default user scopes. Users might not have all scopes. Available scopes: read:bootstrap read:settings read:targets read:tasks read:token write:bootstrap write:targets write:token delete:targets",
                         "default": ""
                     },
                     "expires": {
@@ -1200,6 +1296,30 @@
                     "message": "Bootstrap accepted."
                 }
             },
+            "DeletePayload": {
+                "title": "DeletePayload",
+                "required": [
+                    "targets"
+                ],
+                "type": "object",
+                "properties": {
+                    "targets": {
+                        "title": "Targets",
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "description": "DELETE method required Payload.",
+                "example": {
+                    "targets": [
+                        "v3.4.1/file-3.4.1.tar.gz",
+                        "config-3.4.1.yaml",
+                        "file1.tar.gz"
+                    ]
+                }
+            },
             "GetTokenResponse": {
                 "title": "GetTokenResponse",
                 "required": [
@@ -1226,7 +1346,8 @@
                             "read:token",
                             "write:bootstrap",
                             "write:targets",
-                            "write:token"
+                            "write:token",
+                            "delete:targets"
                         ],
                         "expired": false,
                         "expiration": "2022-08-19T17:29:39"
@@ -1245,51 +1366,6 @@
                             "$ref": "#/components/schemas/ValidationError"
                         }
                     }
-                }
-            },
-            "Payload": {
-                "title": "Payload",
-                "required": [
-                    "targets"
-                ],
-                "type": "object",
-                "properties": {
-                    "targets": {
-                        "title": "Targets",
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/Targets"
-                        }
-                    }
-                },
-                "description": "Targets payload for method POST",
-                "example": {
-                    "targets": [
-                        {
-                            "info": {
-                                "length": 11342,
-                                "hashes": {
-                                    "blake2b-256": "716f6e863f744b9ac22c97ec7b76ea5f5908bc5b2f67c61510bfc4751384ea7a"
-                                },
-                                "custom": {
-                                    "key": "value"
-                                }
-                            },
-                            "path": "file1.tar.gz"
-                        },
-                        {
-                            "info": {
-                                "length": 630,
-                                "hashes": {
-                                    "blake2b-256": "69217a3079908094e11121d042354a7c1f55b6482ca1a51e1b250dfd1ed0eef9"
-                                },
-                                "custom": {
-                                    "key": "value"
-                                }
-                            },
-                            "path": "file2.tar.gz"
-                        }
-                    ]
                 }
             },
             "PayloadTargetsHashes": {
@@ -1968,7 +2044,7 @@
                         ],
                         "task_id": "06ee6db3cbab4b26be505352c2f2e2c3"
                     },
-                    "message": "Target(s) successfully submitted."
+                    "message": "New Target(s) successfully submitted."
                 }
             },
             "kaprien_api__tasks__Response": {
@@ -2013,7 +2089,8 @@
                             "read:token": "Read (GET) tokens",
                             "write:targets": "Write (POST) targets",
                             "write:token": "Write (POST) token",
-                            "write:bootstrap": "Write (POST) bootstrap"
+                            "write:bootstrap": "Write (POST) bootstrap",
+                            "delete:targets": "Delete (DELETE) targets"
                         },
                         "tokenUrl": "/api/v1/token"
                     }

--- a/kaprien_api/api/targets.py
+++ b/kaprien_api/api/targets.py
@@ -22,7 +22,25 @@ router = APIRouter(
     status_code=status.HTTP_202_ACCEPTED,
 )
 def post(
-    payload: targets.Payload,
+    payload: targets.AddPayload,
     _user=Security(validate_token, scopes=[SCOPES_NAMES.write_targets.value]),
 ):
     return targets.post(payload)
+
+
+@router.delete(
+    "/",
+    summary=(
+        "Remove targets files from Metadata. "
+        f"Scope: {SCOPES_NAMES.delete_targets.value}"
+    ),
+    description="Remove targets files from Metadata.",
+    response_model=targets.Response,
+    response_model_exclude_none=True,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+def delete(
+    payload: targets.DeletePayload,
+    _user=Security(validate_token, scopes=[SCOPES_NAMES.delete_targets.value]),
+):
+    return targets.delete(payload)

--- a/kaprien_api/targets.py
+++ b/kaprien_api/targets.py
@@ -30,7 +30,7 @@ class Response(BaseModel):
                 "targets": ["file1.tar.gz", "file2.tar.gz"],
                 "task_id": "06ee6db3cbab4b26be505352c2f2e2c3",
             },
-            "message": "Target(s) successfully submitted.",
+            "message": "New Target(s) successfully submitted.",
         }
         schema_extra = {"example": data_example}
 
@@ -53,9 +53,9 @@ class Targets(BaseModel):
     path: str
 
 
-class Payload(BaseModel):
+class AddPayload(BaseModel):
     """
-    Targets payload for method POST
+    POST method required Payload.
     """
 
     targets: List[Targets]
@@ -67,7 +67,25 @@ class Payload(BaseModel):
         schema_extra = {"example": payload}
 
 
-def post(payload: Payload) -> Response:
+class DeletePayload(BaseModel):
+    """
+    DELETE method required Payload.
+    """
+
+    targets: List[str]
+
+    class Config:
+        payload = {
+            "targets": [
+                "v3.4.1/file-3.4.1.tar.gz",
+                "config-3.4.1.yaml",
+                "file1.tar.gz",
+            ]
+        }
+        schema_extra = {"example": payload}
+
+
+def post(payload: AddPayload) -> Response:
     """
     Post new targets.
     It will send a new task with the validated payload to the
@@ -96,3 +114,36 @@ def post(payload: Payload) -> Response:
         "task_id": task_id,
     }
     return Response(data=data, message="Target(s) successfully submitted.")
+
+
+def delete(payload: DeletePayload) -> Response:
+    """
+    Delete new targets.
+    It will send a new task with the validated payload to the
+    ``metadata_repository`` broker queue.
+    It generates a new task id, syncs with the Redis server, and posts the new
+    task.
+    """
+    if is_bootstrap_done() is False:
+        raise HTTPException(
+            status.HTTP_200_OK,
+            detail={"error": "System has not a Repository Metadata"},
+        )
+
+    task_id = get_task_id()
+    repository_metadata.apply_async(
+        kwargs={
+            "action": "remove_targets",
+            "payload": payload.dict(by_alias=True),
+        },
+        task_id=task_id,
+        queue="metadata_repository",
+        acks_late=True,
+    )
+    data = {
+        "targets": payload.targets,
+        "task_id": task_id,
+    }
+    return Response(
+        data=data, message="Remove Target(s) successfully submitted."
+    )

--- a/kaprien_api/users/crud.py
+++ b/kaprien_api/users/crud.py
@@ -54,3 +54,10 @@ def user_add_scopes(
     db.commit()
     db.refresh(user)
     return user
+
+
+def user_append_scope(db: Session, user: schemas.User, scope: str):
+    user.scopes.append(get_scope_by_name(db, scope))
+    db.commit()
+    db.refresh(user)
+    return user

--- a/tests/unit/api/test_targets.py
+++ b/tests/unit/api/test_targets.py
@@ -15,14 +15,18 @@ class TestPostTargets:
         mocked_repository_metadata = pretend.stub(
             apply_async=pretend.call_recorder(lambda *a, **kw: None)
         )
-        fake_task_id = uuid4().hex
+        monkeypatch.setattr(
+            "kaprien_api.targets.is_bootstrap_done", lambda: True
+        )
         monkeypatch.setattr(
             "kaprien_api.targets.repository_metadata",
             mocked_repository_metadata,
         )
+        fake_task_id = uuid4().hex
         monkeypatch.setattr(
             "kaprien_api.targets.get_task_id", lambda: fake_task_id
         )
+
         response = test_client.post(url, json=payload, headers=token_headers)
         assert response.status_code == status.HTTP_202_ACCEPTED
         assert response.json() == {
@@ -43,6 +47,23 @@ class TestPostTargets:
                 acks_late=True,
             )
         ]
+
+    def test_post_without_bootstrap(
+        self, monkeypatch, test_client, token_headers
+    ):
+        url = "/api/v1/targets/"
+        with open("tests/data_examples/targets/payload.json") as f:
+            f_data = f.read()
+
+        payload = json.loads(f_data)
+        monkeypatch.setattr(
+            "kaprien_api.targets.is_bootstrap_done", lambda: False
+        )
+        response = test_client.post(url, json=payload, headers=token_headers)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == {
+            "detail": {"error": "System has not a Repository Metadata"}
+        }
 
     def test_post_missing_required_field(self, test_client, token_headers):
         url = "/api/v1/targets/"
@@ -97,4 +118,113 @@ class TestPostTargets:
         assert response.status_code == status.HTTP_403_FORBIDDEN
         assert response.json() == {
             "detail": {"error": "scope 'write:targets' not allowed"}
+        }
+
+
+class TestDeleteTargets:
+    def test_delete(self, monkeypatch, test_client, token_headers):
+        url = "/api/v1/targets/"
+
+        payload = {
+            "targets": ["file-v1.0.0_i683.tar.gz", "v0.4.1/file.tar.gz"]
+        }
+
+        monkeypatch.setattr(
+            "kaprien_api.targets.is_bootstrap_done", lambda: True
+        )
+        mocked_repository_metadata = pretend.stub(
+            apply_async=pretend.call_recorder(lambda *a, **kw: None)
+        )
+        monkeypatch.setattr(
+            "kaprien_api.targets.repository_metadata",
+            mocked_repository_metadata,
+        )
+        fake_task_id = uuid4().hex
+        monkeypatch.setattr(
+            "kaprien_api.targets.get_task_id", lambda: fake_task_id
+        )
+
+        response = test_client.delete(url, json=payload, headers=token_headers)
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        assert response.json() == {
+            "data": {
+                "targets": ["file-v1.0.0_i683.tar.gz", "v0.4.1/file.tar.gz"],
+                "task_id": fake_task_id,
+            },
+            "message": "Remove Target(s) successfully submitted.",
+        }
+        assert mocked_repository_metadata.apply_async.calls == [
+            pretend.call(
+                kwargs={
+                    "action": "remove_targets",
+                    "payload": payload,
+                },
+                task_id=fake_task_id,
+                queue="metadata_repository",
+                acks_late=True,
+            )
+        ]
+
+    def test_delete_without_bootstrap(
+        self, monkeypatch, test_client, token_headers
+    ):
+        url = "/api/v1/targets/"
+
+        payload = {
+            "targets": ["file-v1.0.0_i683.tar.gz", "v0.4.1/file.tar.gz"]
+        }
+        monkeypatch.setattr(
+            "kaprien_api.targets.is_bootstrap_done", lambda: False
+        )
+        response = test_client.delete(url, json=payload, headers=token_headers)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == {
+            "detail": {"error": "System has not a Repository Metadata"}
+        }
+
+    def test_delete_missing_required_field(self, test_client, token_headers):
+        url = "/api/v1/targets/"
+
+        payload = {"paths": ["file-v1.0.0_i683.tar.gz", "v0.4.1/file.tar.gz"]}
+
+        response = test_client.delete(url, json=payload, headers=token_headers)
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+    def test_delete_unauthorized_invalid_token(self, test_client):
+        headers = {
+            "Authorization": "Bearer 123456789abcef",
+        }
+        url = "/api/v1/targets/"
+
+        payload = {
+            "targets": ["file-v1.0.0_i683.tar.gz", "v0.4.1/file.tar.gz"]
+        }
+
+        response = test_client.delete(url, json=payload, headers=headers)
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert response.json() == {
+            "detail": {"error": "Failed to validate token"}
+        }
+
+    def test_post_forbidden_user_incorrect_scope_token(self, test_client):
+        token_url = "/api/v1/token/?expires=1"
+        token_payload = {
+            "username": "admin",
+            "password": "secret",
+            "scope": "write:targets",
+        }
+        token = test_client.post(token_url, data=token_payload)
+        headers = {
+            "Authorization": f"Bearer {token.json()['access_token']}",
+        }
+        url = "/api/v1/targets/"
+
+        payload = {
+            "targets": ["file-v1.0.0_i683.tar.gz", "v0.4.1/file.tar.gz"]
+        }
+
+        response = test_client.delete(url, json=payload, headers=headers)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.json() == {
+            "detail": {"error": "scope 'delete:targets' not allowed"}
         }

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -30,6 +30,7 @@ def token_headers(test_client):
             "read:settings "
             "read:token "
             "read:tasks "
+            "delete:targets "
         ),
     }
     token = test_client.post(token_url, data=token_payload)


### PR DESCRIPTION
This adds to the Rest API endpoint `/api/v1/targets` the DELETE method that alows tokens/users with Scope 'delete:target' remove targets.

Closes #107

Additionally it fix the issue in case a new scope is introduced and the admin user needs to have the scopes updated during the start.

Closes #109

Signed-off-by: Kairo Araujo <kairo@kairo.eti.br>