### PR TITLE
fix: env variable for custom Redis result DB

### DIFF
--- a/repository_service_tuf_api/__init__.py
+++ b/repository_service_tuf_api/__init__.py
@@ -155,7 +155,7 @@ celery.conf.broker_url = settings.BROKER_SERVER
 celery.conf.result_backend = (
     f"{settings.REDIS_SERVER}"
     f":{settings.get('REDIS_SERVER_PORT', 6379)}"
-    f"/{settings.get('REDIS_SERVER_DB_REPO_SETTINGS', 0)}"
+    f"/{settings.get('REDIS_SERVER_DB_RESULT', 0)}"
 )
 celery.conf.accept_content = ["json", "application/json"]
 celery.conf.task_serializer = "json"


### PR DESCRIPTION
This commit fixes the environment variable used to setup a custom Redis backend result database ID, as documented in the API Guide documentation for the container configuration.

It was using by mistake the environment variable used to setup the custom Redis repository settings ID for the container.

It impacts the RSTUF deployment for custom scenarios.