### PR TITLE
Move RSTUF to github.com/repository-service-tuf

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: I need help
-    url: https://github.com/vmware/repository-service-tuf
+    url: https://github.com/repository-service-tuf/repository-service-tuf
     about: If you have questions or need help

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -83,5 +83,5 @@ jobs:
       with:
         name: ${{ github.ref_name }}
         tag_name: ${{ github.ref }}
-        body: "docker pull [ghcr.io/vmware/repository-service-tuf-api:${{ github.ref_name }}](https://github.com/vmware/repository-service-tuf-api/pkgs/container/repository-service-tuf-api)"
+        body: "docker pull [ghcr.io/vmware/repository-service-tuf-api:${{ github.ref_name }}](https://github.com/repository-service-tuf/repository-service-tuf-api/pkgs/container/repository-service-tuf-api)"
         files: /tmp/repository-service-tuf-api_${{ github.ref_name }}.tar

--- a/README.rst
+++ b/README.rst
@@ -9,16 +9,16 @@ Repository Service for TUF API
 
 |Test Docker Image build| |Tests and Lint| |Coverage|
 
-.. |Test Docker Image build| image:: https://github.com/vmware/repository-service-tuf-api/actions/workflows/test_docker_build.yml/badge.svg
-  :target: https://github.com/vmware/repository-service-tuf-api/actions/workflows/test_docker_build.yml
-.. |Tests and Lint| image:: https://github.com/vmware/repository-service-tuf-api/actions/workflows/ci.yml/badge.svg
-  :target: https://github.com/vmware/repository-service-tuf-api/actions/workflows/ci.yml
+.. |Test Docker Image build| image:: https://github.com/repository-service-tuf/repository-service-tuf-api/actions/workflows/test_docker_build.yml/badge.svg
+  :target: https://github.com/repository-service-tuf/repository-service-tuf-api/actions/workflows/test_docker_build.yml
+.. |Tests and Lint| image:: https://github.com/repository-service-tuf/repository-service-tuf-api/actions/workflows/ci.yml/badge.svg
+  :target: https://github.com/repository-service-tuf/repository-service-tuf-api/actions/workflows/ci.yml
 .. |Coverage| image:: https://codecov.io/gh/vmware/repository-service-tuf-api/branch/main/graph/badge.svg
   :target: https://codecov.io/gh/vmware/repository-service-tuf-api
 
 
 Repository Service for TUF API is part of `Repository Service for TUF
-<https://github.com/vmware/repository-service-tuf>`_.
+<https://github.com/repository-service-tuf/repository-service-tuf>`_.
 
 
 Usage
@@ -39,7 +39,7 @@ Getting source code
 ===================
 
 `Fork <https://docs.github.com/en/get-started/quickstart/fork-a-repo>`_ the
-repository on `GitHub <https://github.com/vmware/repository-service-tuf-api>`_
+repository on `GitHub <https://github.com/repository-service-tuf/repository-service-tuf-api>`_
 and `clone <https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository>`_
 it to your local machine:
 
@@ -54,7 +54,7 @@ to make sure you stay up-to-date with our repository:
 
 .. code-block:: console
 
-    git remote add upstream https://github.com/vmware/repository-service-tuf-api
+    git remote add upstream https://github.com/repository-service-tuf/repository-service-tuf-api
     git checkout main
     git fetch upstream
     git merge upstream/main

--- a/repository_service_tuf_api/__init__.py
+++ b/repository_service_tuf_api/__init__.py
@@ -169,7 +169,7 @@ celery.conf.result_persistent = True
 celery.conf.task_acks_late = True
 celery.conf.broker_pool_limit = None
 # celery.conf.broker_use_ssl
-# https://github.com/vmware/repository-service-tuf-api/issues/91
+# https://github.com/repository-service-tuf/repository-service-tuf-api/issues/91
 
 
 def is_bootstrap_done():

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import find_packages, setup
 setup(
     name="repository-service-tuf-api",
     version="0.0.1",
-    url="https://github.com/vmware/repository-service-tuf-api",
+    url="https://github.com/repository-service-tuf/repository-service-tuf-api",
     author="Kairo de Araujo",
     author_email="kairo@dearaujo.nl",
     description="Repository Service for TUF REST API",


### PR DESCRIPTION
It is part of the process moving RSTUF to OpenSSF organization.