### PR TITLE
More flexible disabling endpoint feature

### DIFF
--- a/app.py
+++ b/app.py
@@ -51,13 +51,15 @@ def load_endpoints():
         disabled_endpoints.append(f"{api_v1.prefix}{token_v1.prefix}/")
 
     for v1_endpoint in v1_endpoints:
-        for endpoint_route in v1_endpoint.routes:
+        endpoint_routes = v1_endpoint.routes.copy()
+        for endpoint_route in endpoint_routes:
             route = (
                 f"{endpoint_route.methods}{api_v1.prefix}{endpoint_route.path}"
             )
             if route in disabled_endpoints:
                 logging.info(f"Disabled endpoint {route}")
                 v1_endpoint.routes.remove(endpoint_route)
+
         if f"{api_v1.prefix}{v1_endpoint.prefix}/" in disabled_endpoints:
             logging.info(
                 f"Disabled endpoint {api_v1.prefix}{v1_endpoint.prefix}/"

--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@
 
 import json
 import logging
+from typing import List
 
 from fastapi import APIRouter, FastAPI
 
@@ -19,6 +20,15 @@ from repository_service_tuf_api.api.targets import router as targets_v1
 from repository_service_tuf_api.api.tasks import router as tasks_v1
 from repository_service_tuf_api.api.token import router as token_v1
 
+v1_endpoints = [
+    bootstrap_v1,
+    config_v1,
+    metadata_v1,
+    targets_v1,
+    tasks_v1,
+    token_v1,
+]
+
 rstuf_app = FastAPI(
     title="Repository Service for TUF API",
     description="Repository Service for TUF Rest API",
@@ -31,23 +41,27 @@ api_v1 = APIRouter(
     responses={404: {"description": "Not found"}},
 )
 
-if settings.get("BOOTSTRAP_NODE", False) is True:
-    api_v1.include_router(bootstrap_v1)
-logging.info(f"Bootstrap on this node enabled: {settings.BOOTSTRAP_NODE}")
-logging.info(f"Bootstrap ID: {settings_repository.get_fresh('BOOTSTRAP')}")
+# load endpoints
+disabled_endpoints: List[str] = settings.get("DISABLE_ENDPOINTS", "").split(
+    ":"
+)
+if is_auth_enabled is False:
+    disabled_endpoints.append(f"{api_v1.prefix}{token_v1.prefix}/")
 
-if settings.get("TOKENS_NODE", True) is True and is_auth_enabled:
-    api_v1.include_router(token_v1)
-    logging.info(
-        f"Tokens on this node enabled: {settings.get('TOKENS_NODE', True)}"
-    )
-
-api_v1.include_router(config_v1)
-api_v1.include_router(metadata_v1)
-api_v1.include_router(targets_v1)
-api_v1.include_router(tasks_v1)
+for v1_endpoint in v1_endpoints:
+    for endpoint_route in v1_endpoint.routes:
+        route = f"{endpoint_route.methods}{api_v1.prefix}{endpoint_route.path}"
+        if route in disabled_endpoints:
+            logging.info(f"Disabled endpoint {route}")
+            v1_endpoint.routes.remove(endpoint_route)
+    if f"{api_v1.prefix}{v1_endpoint.prefix}/" in disabled_endpoints:
+        logging.info(f"Disabled endpoint {api_v1.prefix}{v1_endpoint.prefix}/")
+    else:
+        api_v1.include_router(v1_endpoint)
 
 rstuf_app.include_router(api_v1)
+
+logging.info(f"Bootstrap ID: {settings_repository.get_fresh('BOOTSTRAP')}")
 
 
 def export_swagger_json(filepath):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,8 +88,6 @@ services:
       - 80:80
     environment:
       - DATA_DIR=./data
-      - RSTUF_BOOTSTRAP_NODE=true
-      - RSTUF_TOKENS_NODE=true
       - RSTUF_BROKER_SERVER="amqp://guest:guest@rabbitmq:5672"
       - RSTUF_REDIS_SERVER="redis://redis"
       - RSTUF_AUTH=true

--- a/docs/source/guide/Docker_README.md
+++ b/docs/source/guide/Docker_README.md
@@ -38,24 +38,6 @@ docker run -p 80:80 \
 
 ### Environment Variables
 
-#### (Optional) `RSTUF_TOKENS_NODE`
-
-The value type is boolean (true/false [case sensitive](https://www.dynaconf.com/configuration/#available-options)).
-Default: true
-
-Disable the container as a token node.
-
-The container is enabled to be a token node by default, the endpoint `/api/v1/token` is visible and accept connections using token authentication and scopes.
-
-#### (Optional) `RSTUF_BOOTSTRAP_NODE`
-
-The value type is boolean (true/false [case sensitive](https://www.dynaconf.com/configuration/#available-options)).
-Default: false
-
-Enable the container to be a bootstrap node.
-
-If the container is enabled to be a bootstrap node, the endpoint `/api/v1/bootstrap` will be visible and accept connections using token authentication and scope `write:bootstrap`
-
 #### (Required) `RSTUF_BROKER_SERVER`
 
 Broker server address.
@@ -106,6 +88,29 @@ Disable/Enable RSTUF built-in token authentication. Default: false
   SECRETS_RSTUF_ADMIN_PASSWORD=/run/secrets/SECRETS_RSTUF_ADMIN_PASSWORD
   SECRETS_RSTUF_TOKEN_KEY=/run/secrets/SECRETS_RSTUF_TOKEN_KEY`
   ```
+
+
+
+#### (Optional) `RSTUF_DISABLED_ENDPOINTS`
+
+Disable specific endpoints or endpoint methods from the API.
+
+This variable receives a list separetad by `:`.
+
+An endpoint can be given `/api/v1/targets`
+
+Note: It will be disabled all methods and all paths GET `/api/v1/targets`,
+POST `/api/v1/targets`, POST `/api/v1/targets/publish` etc.
+
+It is possible to disable specific method endpoint given
+`{'POST'}/api/v1/targets/publish`.
+
+Note: If you give both
+`RSTUF_DISABLE_ENDPOINTS={'POST'}/api/v1/targets/publish:/api/v1/targets` the
+`/api/v1/targets` has higher weigh and will disable all
+
+A list can be given as example bellow
+`RSTUF_DISABLE_ENDPOINTS={'POST'}/api/v1/bootstrap/:/api/v1/metadata/:/api/v1/token/:{'DELETE'}/api/v1/targets/`
 
 
 #### (Optional) `SECRETS_RSTUF_SSL_CERT`

--- a/docs/source/guide/Docker_README.md
+++ b/docs/source/guide/Docker_README.md
@@ -97,19 +97,20 @@ Disable specific endpoints or endpoint methods from the API.
 
 This variable receives a list separetad by `:`.
 
-An endpoint can be given `/api/v1/targets`
+You can disable a whole endpoint.
+For example:
+`RSTUF_DISABLED_ENDPOINTS = "/api/v1/targets"`
+Will disable all methods and all paths  related to v1 `targets`:  
+GET `/api/v1/targets`, POST `/api/v1/targets`, POST `/api/v1/targets/publish` etc.
 
-Note: It will be disabled all methods and all paths GET `/api/v1/targets`,
-POST `/api/v1/targets`, POST `/api/v1/targets/publish` etc.
-
-It is possible to disable specific method endpoint given
+It is possible to disable a specific method endpoint with:
 `{'POST'}/api/v1/targets/publish`.
 
 Note: If you give both
-`RSTUF_DISABLE_ENDPOINTS={'POST'}/api/v1/targets/publish:/api/v1/targets` the
-`/api/v1/targets` has higher weigh and will disable all
+`RSTUF_DISABLE_ENDPOINTS={'POST'}/api/v1/targets/publish:/api/v1/targets` then
+the `/api/v1/targets` has a higher priority and will disable all v1 targets related endpoints.
 
-A list can be given as example bellow
+A list can be given as shown in the example bellow:
 `RSTUF_DISABLE_ENDPOINTS={'POST'}/api/v1/bootstrap/:/api/v1/metadata/:/api/v1/token/:{'DELETE'}/api/v1/targets/`
 
 

--- a/docs/source/guide/api/swagger.json
+++ b/docs/source/guide/api/swagger.json
@@ -90,160 +90,6 @@
                 ]
             }
         },
-        "/api/v1/token/": {
-            "get": {
-                "tags": [
-                    "v1",
-                    "v1"
-                ],
-                "summary": "Get token details. Scope: read:token",
-                "description": "Return the token details. It requires an authenticated token with scope authorization.",
-                "operationId": "get_api_v1_token__get",
-                "security": [
-                    {
-                        "OAuth2PasswordBearer": [
-                            "read:token"
-                        ]
-                    }
-                ],
-                "parameters": [
-                    {
-                        "name": "token",
-                        "in": "query",
-                        "required": true,
-                        "schema": {
-                            "title": "Token",
-                            "description": "Token to be validated",
-                            "required": true,
-                            "type": "string"
-                        },
-                        "description": "Token to be validated"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/GetTokenResponse"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Not found"
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "post": {
-                "tags": [
-                    "v1",
-                    "v1"
-                ],
-                "summary": "Issue token user/password authentication",
-                "description": "Issue a token with scopes for all granted user scope.",
-                "operationId": "post_api_v1_token__post",
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_post_api_v1_token__post"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/PostTokenResponse"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Not found"
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/token/new/": {
-            "post": {
-                "tags": [
-                    "v1",
-                    "v1"
-                ],
-                "summary": "Issue token from authenticated token. Scope: write:token",
-                "description": "Issue token from a valid and existent token.",
-                "operationId": "post_token_api_v1_token_new__post",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/TokenRequestPayload"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/PostTokenResponse"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Not found"
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "OAuth2PasswordBearer": [
-                            "write:token"
-                        ]
-                    }
-                ]
-            }
-        },
         "/api/v1/config/": {
             "get": {
                 "tags": [
@@ -522,6 +368,160 @@
                         }
                     }
                 }
+            }
+        },
+        "/api/v1/token/": {
+            "get": {
+                "tags": [
+                    "v1",
+                    "v1"
+                ],
+                "summary": "Get token details. Scope: read:token",
+                "description": "Return the token details. It requires an authenticated token with scope authorization.",
+                "operationId": "get_api_v1_token__get",
+                "security": [
+                    {
+                        "OAuth2PasswordBearer": [
+                            "read:token"
+                        ]
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "token",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "title": "Token",
+                            "description": "Token to be validated",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "description": "Token to be validated"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetTokenResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "tags": [
+                    "v1",
+                    "v1"
+                ],
+                "summary": "Issue token user/password authentication",
+                "description": "Issue a token with scopes for all granted user scope.",
+                "operationId": "post_api_v1_token__post",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Body_post_api_v1_token__post"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PostTokenResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/token/new/": {
+            "post": {
+                "tags": [
+                    "v1",
+                    "v1"
+                ],
+                "summary": "Issue token from authenticated token. Scope: write:token",
+                "description": "Issue token from a valid and existent token.",
+                "operationId": "post_token_api_v1_token_new__post",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/TokenRequestPayload"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PostTokenResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "OAuth2PasswordBearer": [
+                            "write:token"
+                        ]
+                    }
+                ]
             }
         }
     },

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -5,17 +5,48 @@
 from fastapi import status
 
 
-def test_root(test_client):
-    response = test_client.get("/")
+class TestAPP:
+    def test_root(self, test_client):
+        response = test_client.get("/")
 
-    assert response.url == f"{test_client.base_url}/"
-    assert response.status_code == status.HTTP_200_OK
-    assert "Repository Service for TUF API" in response.text
+        assert response.url == f"{test_client.base_url}/"
+        assert response.status_code == status.HTTP_200_OK
+        assert "Repository Service for TUF API" in response.text
 
+    def test_default_notfound(self, test_client):
+        response = test_client.get("/invalid_url")
 
-def test_default_notfound(test_client):
-    response = test_client.get("/invalid_url")
+        assert response.url == f"{test_client.base_url}/invalid_url"
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert response.json() == {"detail": "Not Found"}
 
-    assert response.url == f"{test_client.base_url}/invalid_url"
-    assert response.status_code == status.HTTP_404_NOT_FOUND
-    assert response.json() == {"detail": "Not Found"}
+    def test_load_endpoints_auth_disabled(self, caplog):
+        import app
+
+        caplog.set_level(app.logging.INFO)
+        app.is_authentication_enabled = False
+        app.load_endpoints()
+        assert (
+            "root",
+            20,
+            "Disabled endpoint /api/v1/token/",
+        ) in caplog.record_tuples
+
+    def test_load_endpoints_disable_prefix_and_method(self, caplog):
+        import app
+
+        app.settings.DISABLE_ENDPOINTS = (
+            "{'POST'}/api/v1/targets/publish/:/api/v1/bootstrap/"
+        )
+        caplog.set_level(app.logging.INFO)
+        app.load_endpoints()
+        assert (
+            "root",
+            20,
+            "Disabled endpoint /api/v1/bootstrap/",
+        ) in caplog.record_tuples
+        assert (
+            "root",
+            20,
+            "Disabled endpoint {'POST'}/api/v1/targets/publish/",
+        ) in caplog.record_tuples

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -26,11 +26,9 @@ class TestAPP:
         caplog.set_level(app.logging.INFO)
         app.is_authentication_enabled = False
         app.load_endpoints()
-        assert (
-            "root",
-            20,
-            "Disabled endpoint /api/v1/token/",
-        ) in caplog.record_tuples
+        assert caplog.record_tuples == [
+            ("root", 20, "Disabled endpoint /api/v1/token/"),
+        ]
 
     def test_load_endpoints_disable_prefix_and_method(self, caplog):
         import app
@@ -39,14 +37,22 @@ class TestAPP:
             "{'POST'}/api/v1/targets/publish/:/api/v1/bootstrap/"
         )
         caplog.set_level(app.logging.INFO)
+        app.is_authentication_enabled = True
         app.load_endpoints()
-        assert (
-            "root",
-            20,
-            "Disabled endpoint /api/v1/bootstrap/",
-        ) in caplog.record_tuples
-        assert (
-            "root",
-            20,
-            "Disabled endpoint {'POST'}/api/v1/targets/publish/",
-        ) in caplog.record_tuples
+        assert caplog.record_tuples == [
+            ("root", 20, "Disabled endpoint /api/v1/bootstrap/"),
+            ("root", 20, "Disabled endpoint {'POST'}/api/v1/targets/publish/"),
+        ]
+
+    def test_load_endpoints_disabling_weight_check(self, caplog):
+        import app
+
+        app.settings.DISABLE_ENDPOINTS = (
+            "{'POST'}/api/v1/targets/publish/:/api/v1/targets/"
+        )
+        app.is_authentication_enabled = True
+        caplog.set_level(app.logging.INFO)
+        app.load_endpoints()
+        assert caplog.record_tuples == [
+            ("root", 20, "Disabled endpoint /api/v1/targets/"),
+        ]

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -24,7 +24,7 @@ class TestAPP:
         import app
 
         caplog.set_level(app.logging.INFO)
-        app.is_authentication_enabled = False
+        app.is_auth_enabled = False
         app.load_endpoints()
         assert caplog.record_tuples == [
             ("root", 20, "Disabled endpoint /api/v1/token/"),
@@ -34,25 +34,26 @@ class TestAPP:
         import app
 
         app.settings.DISABLE_ENDPOINTS = (
-            "{'POST'}/api/v1/targets/publish/:/api/v1/bootstrap/"
+            "{'POST'}/api/v1/token/new/:/api/v1/bootstrap/"
         )
         caplog.set_level(app.logging.INFO)
-        app.is_authentication_enabled = True
+        app.is_auth_enabled = True
         app.load_endpoints()
         assert caplog.record_tuples == [
             ("root", 20, "Disabled endpoint /api/v1/bootstrap/"),
-            ("root", 20, "Disabled endpoint {'POST'}/api/v1/targets/publish/"),
+            ("root", 20, "Disabled endpoint {'POST'}/api/v1/token/new/"),
         ]
 
-    def test_load_endpoints_disabling_weight_check(self, caplog):
+    def test_load_endpoints_disabling_priority_check(self, caplog):
         import app
 
         app.settings.DISABLE_ENDPOINTS = (
             "{'POST'}/api/v1/targets/publish/:/api/v1/targets/"
         )
-        app.is_authentication_enabled = True
+        app.is_auth_enabled = True
         caplog.set_level(app.logging.INFO)
         app.load_endpoints()
         assert caplog.record_tuples == [
+            ("root", 20, "Disabled endpoint {'POST'}/api/v1/targets/publish/"),
             ("root", 20, "Disabled endpoint /api/v1/targets/"),
         ]


### PR DESCRIPTION
This feature gives better flexibility to the RSTUF user to disable endpoints.

The user can disable specific endpoints and methods in a simple configuration using the `RSTUF_DISABLE_ENDPOINTS`.

It reduces the number of settings parameters (environment variables)` RSTUF_BOOTSTRAP_NODE`, and `RSTUF_TOKEN_NODE`, making the feature more flexible as we add more endpoints and methods to the RSTUF API.