### PR TITLE
Allow key custom names/tags

### DIFF
--- a/docs/source/guide/api/swagger.json
+++ b/docs/source/guide/api/swagger.json
@@ -1099,6 +1099,10 @@
                         "additionalProperties": {
                             "type": "string"
                         }
+                    },
+                    "name": {
+                        "title": "Name",
+                        "type": "string"
                     }
                 }
             },

--- a/repository_service_tuf_api/common_models.py
+++ b/repository_service_tuf_api/common_models.py
@@ -46,6 +46,7 @@ class TUFKeys(BaseModel):
     keytype: str
     scheme: str
     keyval: Dict[Literal["public", "private"], str]
+    name: Optional[str]
 
 
 class TUFSignedDelegations(BaseModel):


### PR DESCRIPTION
This is synchronized with the changes in:
https://github.com/repository-service-tuf/repository-service-tuf-cli/pull/277

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>