### PR TITLE
Fix: protection during bootstrap process

### DIFF
--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -810,6 +810,10 @@
                     "bootstrap": {
                         "title": "Bootstrap",
                         "type": "boolean"
+                    },
+                    "state": {
+                        "title": "State",
+                        "type": "string"
                     }
                 }
             },

--- a/repository_service_tuf_api/__init__.py
+++ b/repository_service_tuf_api/__init__.py
@@ -202,10 +202,7 @@ def is_bootstrap_done():
     # correctly reload it because that and the settings_repository.reload() do
     # the job.
     settings_repository.reload()
-    if settings_repository.get_fresh("BOOTSTRAP", None) is None:
-        return False
-    else:
-        return True
+    return settings_repository.get_fresh("BOOTSTRAP")
 
 
 def get_task_id():

--- a/repository_service_tuf_api/config.py
+++ b/repository_service_tuf_api/config.py
@@ -29,10 +29,12 @@ class Response(BaseModel):
 
 
 def get():
-    if is_bootstrap_done() is False:
+    if is_bootstrap_done() is None:
         raise HTTPException(
             status.HTTP_404_NOT_FOUND,
-            detail={"error": "System has not a Repository Metadata"},
+            detail={
+                "error": "Configuration available only after bootstrap process"
+            },
         )
 
     settings_repository.reload()

--- a/repository_service_tuf_api/targets.py
+++ b/repository_service_tuf_api/targets.py
@@ -110,10 +110,11 @@ def post(payload: AddPayload) -> Response:
     It generates a new task id, syncs with the Redis server, and posts the new
     task.
     """
-    if is_bootstrap_done() is False:
+    bootstrap = is_bootstrap_done()
+    if bootstrap is None or "pre" in bootstrap:
         raise HTTPException(
             status.HTTP_200_OK,
-            detail={"error": "System has not a Repository Metadata"},
+            detail={"error": "Bootstrap is not done or still running."},
         )
 
     task_id = get_task_id()
@@ -162,10 +163,11 @@ def delete(payload: DeletePayload) -> Response:
     It generates a new task id, syncs with the Redis server, and posts the new
     task.
     """
-    if is_bootstrap_done() is False:
+    bootstrap = is_bootstrap_done()
+    if bootstrap is None or "pre" in bootstrap:
         raise HTTPException(
             status.HTTP_200_OK,
-            detail={"error": "System has not a Repository Metadata"},
+            detail={"error": "Bootstrap is not done or still running."},
         )
 
     task_id = get_task_id()

--- a/tests/unit/api/test_bootstrap.py
+++ b/tests/unit/api/test_bootstrap.py
@@ -13,7 +13,7 @@ class TestGetBootstrap:
         self, test_client, token_headers, monkeypatch
     ):
         url = "/api/v1/bootstrap/"
-        mocked_check_metadata = pretend.call_recorder(lambda: False)
+        mocked_check_metadata = pretend.call_recorder(lambda: None)
         monkeypatch.setattr(
             "repository_service_tuf_api.bootstrap.is_bootstrap_done",
             mocked_check_metadata,
@@ -33,7 +33,7 @@ class TestGetBootstrap:
     ):
         url = "/api/v1/bootstrap/"
 
-        mocked_check_metadata = pretend.call_recorder(lambda: True)
+        mocked_check_metadata = pretend.call_recorder(lambda: "fakeid")
         monkeypatch.setattr(
             "repository_service_tuf_api.bootstrap.is_bootstrap_done",
             mocked_check_metadata,
@@ -43,7 +43,7 @@ class TestGetBootstrap:
         assert response.status_code == status.HTTP_200_OK
         assert response.url == f"{test_client.base_url}{url}"
         assert response.json() == {
-            "data": {"bootstrap": True},
+            "data": {"bootstrap": True, "state": "finished"},
             "message": "System LOCKED for bootstrap.",
         }
         assert mocked_check_metadata.calls == [pretend.call()]
@@ -99,7 +99,7 @@ class TestPostBootstrap:
     def test_post_bootstrap(self, test_client, monkeypatch, token_headers):
         url = "/api/v1/bootstrap/"
 
-        mocked_check_metadata = pretend.call_recorder(lambda: False)
+        mocked_check_metadata = pretend.call_recorder(lambda: None)
         monkeypatch.setattr(
             "repository_service_tuf_api.bootstrap.is_bootstrap_done",
             mocked_check_metadata,
@@ -148,7 +148,7 @@ class TestPostBootstrap:
     ):
         url = "/api/v1/bootstrap/"
 
-        mocked_check_metadata = pretend.call_recorder(lambda: False)
+        mocked_check_metadata = pretend.call_recorder(lambda: None)
         monkeypatch.setattr(
             "repository_service_tuf_api.bootstrap.is_bootstrap_done",
             mocked_check_metadata,
@@ -198,7 +198,7 @@ class TestPostBootstrap:
     ):
         url = "/api/v1/bootstrap/"
 
-        mocked_check_metadata = pretend.call_recorder(lambda: True)
+        mocked_check_metadata = pretend.call_recorder(lambda: "fakeid")
         monkeypatch.setattr(
             "repository_service_tuf_api.bootstrap.is_bootstrap_done",
             mocked_check_metadata,
@@ -243,7 +243,7 @@ class TestPostBootstrap:
 
         token_headers = {"Authorization": "Bearer h4ck3r"}
 
-        mocked_check_metadata = pretend.call_recorder(lambda: False)
+        mocked_check_metadata = pretend.call_recorder(lambda: None)
         monkeypatch.setattr(
             "repository_service_tuf_api.bootstrap.is_bootstrap_done",
             mocked_check_metadata,
@@ -287,7 +287,7 @@ class TestPostBootstrap:
 
         url = "/api/v1/bootstrap/"
 
-        mocked_check_metadata = pretend.call_recorder(lambda: False)
+        mocked_check_metadata = pretend.call_recorder(lambda: None)
         monkeypatch.setattr(
             "repository_service_tuf_api.bootstrap.is_bootstrap_done",
             mocked_check_metadata,

--- a/tests/unit/api/test_config.py
+++ b/tests/unit/api/test_config.py
@@ -10,7 +10,7 @@ class TestGetSettings:
     def test_get_settings(self, test_client, token_headers, monkeypatch):
         url = "/api/v1/config"
 
-        mocked_check_metadata = pretend.call_recorder(lambda: True)
+        mocked_check_metadata = pretend.call_recorder(lambda: "fakeid")
         monkeypatch.setattr(
             "repository_service_tuf_api.config.is_bootstrap_done",
             mocked_check_metadata,
@@ -31,7 +31,7 @@ class TestGetSettings:
     ):
         url = "/api/v1/config"
 
-        mocked_check_metadata = pretend.call_recorder(lambda: False)
+        mocked_check_metadata = pretend.call_recorder(lambda: None)
         monkeypatch.setattr(
             "repository_service_tuf_api.config.is_bootstrap_done",
             mocked_check_metadata,
@@ -41,13 +41,13 @@ class TestGetSettings:
         assert test_response.status_code == status.HTTP_404_NOT_FOUND
         assert (
             test_response.json().get("detail").get("error")
-            == "System has not a Repository Metadata"
+            == "Configuration available only after bootstrap process"
         )
 
     def test_get_settings_invalid_token(self, test_client, monkeypatch):
         url = "/api/v1/config"
 
-        mocked_check_metadata = pretend.call_recorder(lambda: True)
+        mocked_check_metadata = pretend.call_recorder(lambda: "fakeid")
         monkeypatch.setattr(
             "repository_service_tuf_api.config.is_bootstrap_done",
             mocked_check_metadata,

--- a/tests/unit/api/test_metadata.py
+++ b/tests/unit/api/test_metadata.py
@@ -12,7 +12,7 @@ class TestPostMetadata:
     def test_post_metadata(self, test_client, monkeypatch, token_headers):
         url = "/api/v1/metadata/"
 
-        mocked_check_metadata = pretend.call_recorder(lambda: True)
+        mocked_check_metadata = pretend.call_recorder(lambda: "fakeid")
         monkeypatch.setattr(
             "repository_service_tuf_api.metadata.is_bootstrap_done",
             mocked_check_metadata,
@@ -42,7 +42,7 @@ class TestPostMetadata:
         assert response.status_code == status.HTTP_202_ACCEPTED
         assert response.url == f"{test_client.base_url}{url}"
         assert response.json() == {
-            "message": "Metadata rotation accepted.",
+            "message": "Metadata update accepted.",
             "data": {"task_id": "123"},
         }
 
@@ -51,7 +51,7 @@ class TestPostMetadata:
     ):
         url = "/api/v1/metadata/"
 
-        mocked_check_metadata = pretend.call_recorder(lambda: False)
+        mocked_check_metadata = pretend.call_recorder(lambda: None)
         monkeypatch.setattr(
             "repository_service_tuf_api.metadata.is_bootstrap_done",
             mocked_check_metadata,
@@ -68,7 +68,7 @@ class TestPostMetadata:
         assert response.status_code == status.HTTP_200_OK
         assert response.url == f"{test_client.base_url}{url}"
         assert response.json() == {
-            "detail": {"error": "Metadata rotation requires bootstrap done."}
+            "detail": {"error": "Metadata update requires bootstrap done."}
         }
 
     def test_post_metadata_empty_payload(self, test_client, token_headers):
@@ -93,7 +93,7 @@ class TestPostMetadata:
             ]
         }
 
-    def test_post_metadata_invalid_token(self, test_client, monkeypatch):
+    def test_post_metadata_invalid_token(self, test_client):
         url = "/api/v1/metadata/"
 
         token_headers = {"Authorization": "Bearer h4ck3r"}
@@ -111,9 +111,7 @@ class TestPostMetadata:
             "detail": {"error": "Failed to validate token"}
         }
 
-    def test_post_metadata_incorrect_scope_token(
-        self, test_client, monkeypatch
-    ):
+    def test_post_metadata_incorrect_scope_token(self, test_client):
         token_url = "/api/v1/token/?expires=1"
         token_payload = {
             "username": "admin",

--- a/tests/unit/tuf_repository_service_api/test__init__.py
+++ b/tests/unit/tuf_repository_service_api/test__init__.py
@@ -14,7 +14,7 @@ class TestInit:
         )
 
         result = repository_service_tuf_api.is_bootstrap_done()
-        assert result is False
+        assert result is None
 
     def test_is_bootstrap_done_with_task_id(self):
         repository_service_tuf_api.settings_repository = pretend.stub(
@@ -23,7 +23,7 @@ class TestInit:
         )
 
         result = repository_service_tuf_api.is_bootstrap_done()
-        assert result is True
+        assert result == "taskid"
 
     def test_pre_lock_bootstrap(self):
         fake_settings = pretend.stub(

--- a/tests/unit/tuf_repository_service_api/test_bootstrap.py
+++ b/tests/unit/tuf_repository_service_api/test_bootstrap.py
@@ -49,3 +49,26 @@ class TestBootstrap:
         assert len(bootstrap.repository_metadata.AsyncResult.calls) > 1
         assert fake_task.revoke.calls == [pretend.call(terminate=True)]
         assert bootstrap.release_bootstrap_lock.calls == [pretend.call()]
+
+    def test_get_bootstrap_none(self):
+        bootstrap.is_bootstrap_done = pretend.call_recorder(lambda: None)
+        bootstrap.get_bootstrap() == bootstrap.BootstrapGetResponse(
+            data=bootstrap.GetData(bootstrap=False, state=None),
+            message="System available for bootstrap.",
+        )
+
+    def test_get_bootstrap_pre(self):
+        bootstrap.is_bootstrap_done = pretend.call_recorder(
+            lambda: "pre-fakeid"
+        )
+        bootstrap.get_bootstrap() == bootstrap.BootstrapGetResponse(
+            data=bootstrap.GetData(bootstrap=False, state="pre"),
+            message="System LOCKED for bootstrap.",
+        )
+
+    def test_get_bootstrap_finished(self):
+        bootstrap.is_bootstrap_done = pretend.call_recorder(lambda: "fakeid")
+        bootstrap.get_bootstrap() == bootstrap.BootstrapGetResponse(
+            data=bootstrap.GetData(bootstrap=False, state="finished"),
+            message="System LOCKED for bootstrap.",
+        )


### PR DESCRIPTION
This change considers the bootstrap `pre` lock done by the RSTUF API and avoid user can start adding/removing targets before the process finishes.

Closes #342