### PR TITLE
Metadata update: update payload and messages

### DIFF
--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -645,7 +645,7 @@
                 "type": "object",
                 "properties": {
                     "settings": {
-                        "$ref": "#/components/schemas/repository_service_tuf_api__bootstrap__Settings"
+                        "$ref": "#/components/schemas/Settings"
                     },
                     "metadata": {
                         "title": "Metadata",
@@ -864,14 +864,10 @@
             "MetadataPostPayload": {
                 "title": "MetadataPostPayload",
                 "required": [
-                    "settings",
                     "metadata"
                 ],
                 "type": "object",
                 "properties": {
-                    "settings": {
-                        "$ref": "#/components/schemas/repository_service_tuf_api__metadata__Settings"
-                    },
                     "metadata": {
                         "title": "Metadata",
                         "type": "object",
@@ -1071,6 +1067,26 @@
                     "targets_online_key": {
                         "title": "Targets Online Key",
                         "type": "boolean"
+                    }
+                }
+            },
+            "Settings": {
+                "title": "Settings",
+                "required": [
+                    "expiration",
+                    "services"
+                ],
+                "type": "object",
+                "properties": {
+                    "expiration": {
+                        "title": "Expiration",
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "integer"
+                        }
+                    },
+                    "services": {
+                        "$ref": "#/components/schemas/ServiceSettings"
                     }
                 }
             },
@@ -1512,26 +1528,6 @@
                     }
                 }
             },
-            "repository_service_tuf_api__bootstrap__Settings": {
-                "title": "Settings",
-                "required": [
-                    "expiration",
-                    "services"
-                ],
-                "type": "object",
-                "properties": {
-                    "expiration": {
-                        "title": "Expiration",
-                        "type": "object",
-                        "additionalProperties": {
-                            "type": "integer"
-                        }
-                    },
-                    "services": {
-                        "$ref": "#/components/schemas/ServiceSettings"
-                    }
-                }
-            },
             "repository_service_tuf_api__config__Response": {
                 "title": "Response",
                 "required": [
@@ -1587,22 +1583,6 @@
                     "task_id": {
                         "title": "Task Id",
                         "type": "string"
-                    }
-                }
-            },
-            "repository_service_tuf_api__metadata__Settings": {
-                "title": "Settings",
-                "required": [
-                    "expiration"
-                ],
-                "type": "object",
-                "properties": {
-                    "expiration": {
-                        "title": "Expiration",
-                        "type": "object",
-                        "additionalProperties": {
-                            "type": "integer"
-                        }
                     }
                 }
             },

--- a/repository_service_tuf_api/__init__.py
+++ b/repository_service_tuf_api/__init__.py
@@ -78,11 +78,13 @@ secrets_settings = Dynaconf(
 
 is_auth_enabled: bool = settings.get("AUTH", False)
 
+
 SECRET_KEY: Optional[str] = None
 ADMIN_PASSWORD: Optional[str] = None
 db: Optional[sessionmaker] = None
 
 if is_auth_enabled is True:
+    logging.info("AUTH enabled")
     # Tokens
     if secrets_settings.TOKEN_KEY.startswith("/run/secrets/"):
         try:

--- a/repository_service_tuf_api/metadata.py
+++ b/repository_service_tuf_api/metadata.py
@@ -20,12 +20,7 @@ from repository_service_tuf_api.common_models import (
 )
 
 
-class Settings(BaseModel):
-    expiration: Dict[Roles.values(), int]
-
-
 class MetadataPostPayload(BaseModel):
-    settings: Settings
     metadata: Dict[Literal[Roles.ROOT.value], TUFMetadata]
 
     class Config:
@@ -61,7 +56,7 @@ def post_metadata(payload: MetadataPostPayload) -> MetadataPostResponse:
         raise HTTPException(
             status_code=status.HTTP_200_OK,
             detail=BaseErrorResponse(
-                error="Metadata rotation requires bootstrap done."
+                error="Metadata update requires bootstrap done."
             ).dict(exclude_none=True),
         )
 
@@ -77,5 +72,5 @@ def post_metadata(payload: MetadataPostPayload) -> MetadataPostResponse:
     )
 
     return MetadataPostResponse(
-        data={"task_id": task_id}, message="Metadata rotation accepted."
+        data={"task_id": task_id}, message="Metadata update accepted."
     )

--- a/tests/unit/api/test_metadata.py
+++ b/tests/unit/api/test_metadata.py
@@ -42,7 +42,7 @@ class TestPostMetadata:
         assert response.status_code == status.HTTP_202_ACCEPTED
         assert response.url == f"{test_client.base_url}{url}"
         assert response.json() == {
-            "message": "Metadata rotation accepted.",
+            "message": "Metadata update accepted.",
             "data": {"task_id": "123"},
         }
 
@@ -68,7 +68,7 @@ class TestPostMetadata:
         assert response.status_code == status.HTTP_200_OK
         assert response.url == f"{test_client.base_url}{url}"
         assert response.json() == {
-            "detail": {"error": "Metadata rotation requires bootstrap done."}
+            "detail": {"error": "Metadata update requires bootstrap done."}
         }
 
     def test_post_metadata_empty_payload(self, test_client, token_headers):
@@ -80,11 +80,6 @@ class TestPostMetadata:
         assert response.url == f"{test_client.base_url}{url}"
         assert response.json() == {
             "detail": [
-                {
-                    "loc": ["body", "settings"],
-                    "msg": "field required",
-                    "type": "value_error.missing",
-                },
                 {
                     "loc": ["body", "metadata"],
                     "msg": "field required",


### PR DESCRIPTION
Metadata update: update payload and messages to follow latest decision made during the CLI implementation like removing expiration date for all roles and calling this feature `metadata update` instead of `metadata rotation`.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>