### PR TITLE
Add BDD tests for Token Feature to RSTUF API

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -40,6 +40,7 @@ myst-parser = "*"
 pre-commit = "*"
 bandit = "*"
 httpx = "*"
+pytest-bdd = "*"
 
 [requires]
 python_version = "3.10"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f1f75d0f7f98dcb349ae9dcdadc406fe3e6711f0004adb426c80e3305594c39f"
+            "sha256": "87dda03c2f13fe82b131c8b09635793abb443ac78d75faa87e1b6350c216e1ee"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -141,11 +141,11 @@
         },
         "exceptiongroup": {
             "hashes": [
-                "sha256:12c3e887d6485d16943a309616de20ae5582633e0a2eda17f4e10fd61c1e8af5",
-                "sha256:e346e69d186172ca7cf029c8c1d16235aa0e04035e5750b4b95039e65204328f"
+                "sha256:097acd85d473d75af5bb98e41b61ff7fe35efe6675e4f9370ec6ec5126d160e9",
+                "sha256:343280667a4585d195ca1cf9cef84a4e178c4b6cf2274caef9859782b567d5e3"
             ],
             "markers": "python_version < '3.11'",
-            "version": "==1.1.2"
+            "version": "==1.1.3"
         },
         "fastapi": {
             "hashes": [
@@ -329,11 +329,11 @@
         },
         "redis": {
             "hashes": [
-                "sha256:585dc516b9eb042a619ef0a39c3d7d55fe81bdb4df09a52c9cdde0d07bf1aa7d",
-                "sha256:e2b03db868160ee4591de3cb90d40ebb50a90dd302138775937f6a42b7ed183c"
+                "sha256:06570d0b2d84d46c21defc550afbaada381af82f5b83e5b3777600e05d8e2ed0",
+                "sha256:5cea6c0d335c9a7332a460ed8729ceabb4d0c489c7285b0a86dbbf8a017bd120"
             ],
             "index": "pypi",
-            "version": "==4.6.0"
+            "version": "==5.0.0"
         },
         "rsa": {
             "hashes": [
@@ -361,50 +361,50 @@
         },
         "sqlalchemy": {
             "hashes": [
-                "sha256:024d2f67fb3ec697555e48caeb7147cfe2c08065a4f1a52d93c3d44fc8e6ad1c",
-                "sha256:0bf0fd65b50a330261ec7fe3d091dfc1c577483c96a9fa1e4323e932961aa1b5",
-                "sha256:16a310f5bc75a5b2ce7cb656d0e76eb13440b8354f927ff15cbaddd2523ee2d1",
-                "sha256:1d90ccc15ba1baa345796a8fb1965223ca7ded2d235ccbef80a47b85cea2d71a",
-                "sha256:22bafb1da60c24514c141a7ff852b52f9f573fb933b1e6b5263f0daa28ce6db9",
-                "sha256:2c69ce70047b801d2aba3e5ff3cba32014558966109fecab0c39d16c18510f15",
-                "sha256:2e7b69d9ced4b53310a87117824b23c509c6fc1f692aa7272d47561347e133b6",
-                "sha256:314145c1389b021a9ad5aa3a18bac6f5d939f9087d7fc5443be28cba19d2c972",
-                "sha256:3afa8a21a9046917b3a12ffe016ba7ebe7a55a6fc0c7d950beb303c735c3c3ad",
-                "sha256:430614f18443b58ceb9dedec323ecddc0abb2b34e79d03503b5a7579cd73a531",
-                "sha256:43699eb3f80920cc39a380c159ae21c8a8924fe071bccb68fc509e099420b148",
-                "sha256:539010665c90e60c4a1650afe4ab49ca100c74e6aef882466f1de6471d414be7",
-                "sha256:57d100a421d9ab4874f51285c059003292433c648df6abe6c9c904e5bd5b0828",
-                "sha256:5831138f0cc06b43edf5f99541c64adf0ab0d41f9a4471fd63b54ae18399e4de",
-                "sha256:584f66e5e1979a7a00f4935015840be627e31ca29ad13f49a6e51e97a3fb8cae",
-                "sha256:5d6afc41ca0ecf373366fd8e10aee2797128d3ae45eb8467b19da4899bcd1ee0",
-                "sha256:61ada5831db36d897e28eb95f0f81814525e0d7927fb51145526c4e63174920b",
-                "sha256:6b54d1ad7a162857bb7c8ef689049c7cd9eae2f38864fc096d62ae10bc100c7d",
-                "sha256:7351c05db355da112e056a7b731253cbeffab9dfdb3be1e895368513c7d70106",
-                "sha256:77a14fa20264af73ddcdb1e2b9c5a829b8cc6b8304d0f093271980e36c200a3f",
-                "sha256:851a37898a8a39783aab603c7348eb5b20d83c76a14766a43f56e6ad422d1ec8",
-                "sha256:89bc2b374ebee1a02fd2eae6fd0570b5ad897ee514e0f84c5c137c942772aa0c",
-                "sha256:8e712cfd2e07b801bc6b60fdf64853bc2bd0af33ca8fa46166a23fe11ce0dbb0",
-                "sha256:8f9eb4575bfa5afc4b066528302bf12083da3175f71b64a43a7c0badda2be365",
-                "sha256:8fc05b59142445a4efb9c1fd75c334b431d35c304b0e33f4fa0ff1ea4890f92e",
-                "sha256:96f0463573469579d32ad0c91929548d78314ef95c210a8115346271beeeaaa2",
-                "sha256:9deaae357edc2091a9ed5d25e9ee8bba98bcfae454b3911adeaf159c2e9ca9e3",
-                "sha256:a752b7a9aceb0ba173955d4f780c64ee15a1a991f1c52d307d6215c6c73b3a4c",
-                "sha256:ae7473a67cd82a41decfea58c0eac581209a0aa30f8bc9190926fbf628bb17f7",
-                "sha256:b15afbf5aa76f2241184c1d3b61af1a72ba31ce4161013d7cb5c4c2fca04fd6e",
-                "sha256:c896d4e6ab2eba2afa1d56be3d0b936c56d4666e789bfc59d6ae76e9fcf46145",
-                "sha256:cb4e688f6784427e5f9479d1a13617f573de8f7d4aa713ba82813bcd16e259d1",
-                "sha256:cda283700c984e699e8ef0fcc5c61f00c9d14b6f65a4f2767c97242513fcdd84",
-                "sha256:cf7b5e3856cbf1876da4e9d9715546fa26b6e0ba1a682d5ed2fc3ca4c7c3ec5b",
-                "sha256:d6894708eeb81f6d8193e996257223b6bb4041cb05a17cd5cf373ed836ef87a2",
-                "sha256:d8f2afd1aafded7362b397581772c670f20ea84d0a780b93a1a1529da7c3d369",
-                "sha256:dd4d410a76c3762511ae075d50f379ae09551d92525aa5bb307f8343bf7c2c12",
-                "sha256:eb60699de43ba1a1f77363f563bb2c652f7748127ba3a774f7cf2c7804aa0d3d",
-                "sha256:f469f15068cd8351826df4080ffe4cc6377c5bf7d29b5a07b0e717dddb4c7ea2",
-                "sha256:f82c310ddf97b04e1392c33cf9a70909e0ae10a7e2ddc1d64495e3abdc5d19fb",
-                "sha256:fa51ce4aea583b0c6b426f4b0563d3535c1c75986c4373a0987d84d22376585b"
+                "sha256:1506e988ebeaaf316f183da601f24eedd7452e163010ea63dbe52dc91c7fc70e",
+                "sha256:1a58052b5a93425f656675673ef1f7e005a3b72e3f2c91b8acca1b27ccadf5f4",
+                "sha256:1b74eeafaa11372627ce94e4dc88a6751b2b4d263015b3523e2b1e57291102f0",
+                "sha256:1be86ccea0c965a1e8cd6ccf6884b924c319fcc85765f16c69f1ae7148eba64b",
+                "sha256:1d35d49a972649b5080557c603110620a86aa11db350d7a7cb0f0a3f611948a0",
+                "sha256:243d0fb261f80a26774829bc2cee71df3222587ac789b7eaf6555c5b15651eed",
+                "sha256:26a3399eaf65e9ab2690c07bd5cf898b639e76903e0abad096cd609233ce5208",
+                "sha256:27d554ef5d12501898d88d255c54eef8414576f34672e02fe96d75908993cf53",
+                "sha256:3364b7066b3c7f4437dd345d47271f1251e0cfb0aba67e785343cdbdb0fff08c",
+                "sha256:3423dc2a3b94125094897118b52bdf4d37daf142cbcf26d48af284b763ab90e9",
+                "sha256:3c6aceebbc47db04f2d779db03afeaa2c73ea3f8dcd3987eb9efdb987ffa09a3",
+                "sha256:3ce5e81b800a8afc870bb8e0a275d81957e16f8c4b62415a7b386f29a0cb9763",
+                "sha256:411e7f140200c02c4b953b3dbd08351c9f9818d2bd591b56d0fa0716bd014f1e",
+                "sha256:4cde2e1096cbb3e62002efdb7050113aa5f01718035ba9f29f9d89c3758e7e4e",
+                "sha256:5768c268df78bacbde166b48be788b83dddaa2a5974b8810af422ddfe68a9bc8",
+                "sha256:599ccd23a7146e126be1c7632d1d47847fa9f333104d03325c4e15440fc7d927",
+                "sha256:5ed61e3463021763b853628aef8bc5d469fe12d95f82c74ef605049d810f3267",
+                "sha256:63a368231c53c93e2b67d0c5556a9836fdcd383f7e3026a39602aad775b14acf",
+                "sha256:63e73da7fb030ae0a46a9ffbeef7e892f5def4baf8064786d040d45c1d6d1dc5",
+                "sha256:6eb6d77c31e1bf4268b4d61b549c341cbff9842f8e115ba6904249c20cb78a61",
+                "sha256:6f8a934f9dfdf762c844e5164046a9cea25fabbc9ec865c023fe7f300f11ca4a",
+                "sha256:6fe7d61dc71119e21ddb0094ee994418c12f68c61b3d263ebaae50ea8399c4d4",
+                "sha256:759b51346aa388c2e606ee206c0bc6f15a5299f6174d1e10cadbe4530d3c7a98",
+                "sha256:76fdfc0f6f5341987474ff48e7a66c3cd2b8a71ddda01fa82fedb180b961630a",
+                "sha256:77d37c1b4e64c926fa3de23e8244b964aab92963d0f74d98cbc0783a9e04f501",
+                "sha256:79543f945be7a5ada9943d555cf9b1531cfea49241809dd1183701f94a748624",
+                "sha256:79fde625a0a55220d3624e64101ed68a059c1c1f126c74f08a42097a72ff66a9",
+                "sha256:7d3f175410a6db0ad96b10bfbb0a5530ecd4fcf1e2b5d83d968dd64791f810ed",
+                "sha256:8dd77fd6648b677d7742d2c3cc105a66e2681cc5e5fb247b88c7a7b78351cf74",
+                "sha256:a3f0dd6d15b6dc8b28a838a5c48ced7455c3e1fb47b89da9c79cc2090b072a50",
+                "sha256:bcb04441f370cbe6e37c2b8d79e4af9e4789f626c595899d94abebe8b38f9a4d",
+                "sha256:c3d99ba99007dab8233f635c32b5cd24fb1df8d64e17bc7df136cedbea427897",
+                "sha256:ca8a5ff2aa7f3ade6c498aaafce25b1eaeabe4e42b73e25519183e4566a16fc6",
+                "sha256:cb0d3e94c2a84215532d9bcf10229476ffd3b08f481c53754113b794afb62d14",
+                "sha256:d1b09ba72e4e6d341bb5bdd3564f1cea6095d4c3632e45dc69375a1dbe4e26ec",
+                "sha256:d32b5ffef6c5bcb452723a496bad2d4c52b346240c59b3e6dba279f6dcc06c14",
+                "sha256:d3793dcf5bc4d74ae1e9db15121250c2da476e1af8e45a1d9a52b1513a393459",
+                "sha256:dd81466bdbc82b060c3c110b2937ab65ace41dfa7b18681fdfad2f37f27acdd7",
+                "sha256:e4e571af672e1bb710b3cc1a9794b55bce1eae5aed41a608c0401885e3491179",
+                "sha256:ea8186be85da6587456c9ddc7bf480ebad1a0e6dcbad3967c4821233a4d4df57",
+                "sha256:eefebcc5c555803065128401a1e224a64607259b5eb907021bf9b175f315d2a6"
             ],
             "index": "pypi",
-            "version": "==2.0.19"
+            "version": "==2.0.20"
         },
         "starlette": {
             "hashes": [
@@ -825,11 +825,11 @@
         },
         "exceptiongroup": {
             "hashes": [
-                "sha256:12c3e887d6485d16943a309616de20ae5582633e0a2eda17f4e10fd61c1e8af5",
-                "sha256:e346e69d186172ca7cf029c8c1d16235aa0e04035e5750b4b95039e65204328f"
+                "sha256:097acd85d473d75af5bb98e41b61ff7fe35efe6675e4f9370ec6ec5126d160e9",
+                "sha256:343280667a4585d195ca1cf9cef84a4e178c4b6cf2274caef9859782b567d5e3"
             ],
             "markers": "python_version < '3.11'",
-            "version": "==1.1.2"
+            "version": "==1.1.3"
         },
         "filelock": {
             "hashes": [
@@ -956,6 +956,14 @@
                 "sha256:aafb67fc49cfb1d89e46a3443ac747e15f4bb42df20ed04f067ad9efbee256ab"
             ],
             "version": "==0.3.1"
+        },
+        "mako": {
+            "hashes": [
+                "sha256:c97c79c018b9165ac9922ae4f32da095ffd3c4e6872b45eded42926deea46818",
+                "sha256:d60a3903dc3bb01a18ad6a89cdbe2e4eadc69c0bc8ef1e3773ba53d44c3f7a34"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==1.2.4"
         },
         "markdown-it-py": {
             "hashes": [
@@ -1085,6 +1093,21 @@
             "markers": "python_version >= '3.7'",
             "version": "==23.1"
         },
+        "parse": {
+            "hashes": [
+                "sha256:371ed3800dc63983832159cc9373156613947707bc448b5215473a219dbd4362",
+                "sha256:cc3a47236ff05da377617ddefa867b7ba983819c664e1afe46249e5b469be464"
+            ],
+            "version": "==1.19.1"
+        },
+        "parse-type": {
+            "hashes": [
+                "sha256:06d39a8b70fde873eb2a131141a0e79bb34a432941fb3d66fad247abafc9766c",
+                "sha256:79b1f2497060d0928bc46016793f1fca1057c4aacdf15ef876aa48d75a73a355"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.6.2"
+        },
         "pathspec": {
             "hashes": [
                 "sha256:1d6ed233af05e679efb96b1851550ea95bbb64b7c490b0f5aa52996c11e92a20",
@@ -1179,6 +1202,14 @@
             ],
             "index": "pypi",
             "version": "==7.4.0"
+        },
+        "pytest-bdd": {
+            "hashes": [
+                "sha256:138af3592bcce5d4684b0d690777cf199b39ce45d423ca28086047ffe6111010",
+                "sha256:57eba5878d77036f356a85fb1d108cb061d8af4fb4d032b1a424fa9abe9e498b"
+            ],
+            "index": "pypi",
+            "version": "==6.1.1"
         },
         "pyyaml": {
             "hashes": [
@@ -1355,11 +1386,11 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:11e52c67415a381d10d6b462ced9cfb97066179f0e871399e006c4ab101fc85f",
-                "sha256:baf1fdb41c6da4cd2eae722e135500da913332ab3f2f5c7d33af9b492acb5235"
+                "sha256:d59c97e7b774979a5ccb96388efc9eb65518004537e85d52e81eaee89ab6dd91",
+                "sha256:e13e1b0bc760e9b0127eda042845999b2f913e12437046e663b833aa96d89715"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==68.0.0"
+            "markers": "python_version >= '3.8'",
+            "version": "==68.1.0"
         },
         "six": {
             "hashes": [
@@ -1410,27 +1441,27 @@
         },
         "sphinxcontrib-applehelp": {
             "hashes": [
-                "sha256:a59274de7a952a99af36b8a5092352d9249279c0e3280b7dceaae8e15873c942",
-                "sha256:c0578efa23cab5a2f3aaa8af5691b952433f4fdfaac255befd3452448e7ea4a4"
+                "sha256:094c4d56209d1734e7d252f6e0b3ccc090bd52ee56807a5d9315b19c122ab15d",
+                "sha256:39fdc8d762d33b01a7d8f026a3b7d71563ea3b72787d5f00ad8465bd9d6dfbfa"
             ],
             "index": "pypi",
-            "version": "==1.0.6"
+            "version": "==1.0.7"
         },
         "sphinxcontrib-devhelp": {
             "hashes": [
-                "sha256:4fd751c63dc40895ac8740948f26bf1a3c87e4e441cc008672abd1cb2bc8a3d1",
-                "sha256:d4e20a17f78865d4096733989b5efa0d5e7743900e98e1f6ecd6f489380febc8"
+                "sha256:63b41e0d38207ca40ebbeabcf4d8e51f76c03e78cd61abe118cf4435c73d4212",
+                "sha256:fe8009aed765188f08fcaadbb3ea0d90ce8ae2d76710b7e29ea7d047177dae2f"
             ],
             "index": "pypi",
-            "version": "==1.0.4"
+            "version": "==1.0.5"
         },
         "sphinxcontrib-htmlhelp": {
             "hashes": [
-                "sha256:14358d0f88ccf58447f2b54343cdcc0012f32de2f8d27cf934fdbc0b362f9597",
-                "sha256:abee4e6c5471203ad2fc40dc6a16ed99884a5d6b15a6f79c9269a7e82cf04149"
+                "sha256:6c26a118a05b76000738429b724a0568dbde5b72391a688577da08f11891092a",
+                "sha256:8001661c077a73c29beaf4a79968d0726103c5605e27db92b9ebed8bab1359e9"
             ],
             "index": "pypi",
-            "version": "==2.0.3"
+            "version": "==2.0.4"
         },
         "sphinxcontrib-httpdomain": {
             "hashes": [
@@ -1472,19 +1503,19 @@
         },
         "sphinxcontrib-qthelp": {
             "hashes": [
-                "sha256:962730a6ad15d21fd6760b14c9e95c00a097413595aa6ee871dd9dfa4b002a16",
-                "sha256:d31d1a1beaf3894866bb318fb712f1edc82687f1c06235a01e5b2c50c36d5c40"
+                "sha256:62b9d1a186ab7f5ee3356d906f648cacb7a6bdb94d201ee7adf26db55092982d",
+                "sha256:bf76886ee7470b934e363da7a954ea2825650013d367728588732c7350f49ea4"
             ],
             "index": "pypi",
-            "version": "==1.0.5"
+            "version": "==1.0.6"
         },
         "sphinxcontrib-serializinghtml": {
             "hashes": [
-                "sha256:424164fc3a8b4355a29d5ea8b7f18199022d160c8f7b96e68bb6c50217729b87",
-                "sha256:ca31afee32e1508cff4034e258060ce2c81a3b1c49e77da60fdb61f0e7a73c22"
+                "sha256:27849e7227277333d3d32f17c138ee148a51fa01f888a41cd6d4e73bcabe2d06",
+                "sha256:aaf3026335146e688fd209b72320314b1b278320cf232e3cda198f873838511a"
             ],
             "index": "pypi",
-            "version": "==1.1.7"
+            "version": "==1.1.8"
         },
         "stevedore": {
             "hashes": [
@@ -1504,11 +1535,19 @@
         },
         "tox": {
             "hashes": [
-                "sha256:2adacf435b12ccf10b9dfa9975d8ec0afd7cbae44d300463140d2117b968037b",
-                "sha256:4991305a56983d750a0d848a34242be290452aa88d248f1bf976e4036ee8b213"
+                "sha256:9b6d38fe422599d084afd89375b4803f4bc1f8f16573c77c8fd8ffcc6938f1ff",
+                "sha256:c80de60fe26f9a009b0a763888bf2099ccfbef50a0279a6b9f6de40eb4eb7457"
             ],
             "index": "pypi",
-            "version": "==4.8.0"
+            "version": "==4.9.0"
+        },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:440d5dd3af93b060174bf433bccd69b0babc3b15b1a8dca43789fd7f61514b36",
+                "sha256:b75ddc264f0ba5615db7ba217daeb99701ad295353c45f9e95963337ceeeffb2"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==4.7.1"
         },
         "urllib3": {
             "hashes": [

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,7 +17,7 @@ coverage==7.3.0
 cryptography==41.0.3
 distlib==0.3.7
 docutils==0.18.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
-exceptiongroup==1.1.2; python_version < '3.11'
+exceptiongroup==1.1.3; python_version < '3.11'
 filelock==3.12.2; python_version >= '3.7'
 flake8==6.1.0
 gitdb==4.0.10; python_version >= '3.7'
@@ -34,6 +34,7 @@ jinja2==3.1.2; python_version >= '3.7'
 jsonschema==4.19.0; python_version >= '3.8'
 jsonschema-specifications==2023.7.1; python_version >= '3.8'
 m2r==0.3.1
+mako==1.2.4; python_version >= '3.7'
 markdown-it-py==3.0.0; python_version >= '3.8'
 markupsafe==2.1.3; python_version >= '3.7'
 mccabe==0.7.0; python_version >= '3.6'
@@ -44,6 +45,8 @@ mypy-extensions==1.0.0; python_version >= '3.5'
 myst-parser==2.0.0
 nodeenv==1.8.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'
 packaging==23.1; python_version >= '3.7'
+parse==1.19.1
+parse-type==0.6.2; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 pathspec==0.11.2; python_version >= '3.7'
 pbr==5.11.1; python_version >= '2.6'
 platformdirs==3.10.0; python_version >= '3.7'
@@ -56,31 +59,33 @@ pyflakes==3.1.0; python_version >= '3.8'
 pygments==2.16.1; python_version >= '3.7'
 pyproject-api==1.5.3; python_version >= '3.7'
 pytest==7.4.0
+pytest-bdd==6.1.1
 pyyaml==6.0.1; python_version >= '3.6'
 referencing==0.30.2; python_version >= '3.8'
 requests==2.31.0; python_version >= '3.7'
 rich==13.5.2; python_full_version >= '3.7.0'
 rpds-py==0.9.2; python_version >= '3.8'
-setuptools==68.0.0; python_version >= '3.7'
+setuptools==68.1.0; python_version >= '3.8'
 six==1.16.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 smmap==5.0.0; python_version >= '3.6'
 sniffio==1.3.0; python_version >= '3.7'
 snowballstemmer==2.2.0
 sphinx==6.2.1
 sphinx-rtd-theme==1.2.2
-sphinxcontrib-applehelp==1.0.6
-sphinxcontrib-devhelp==1.0.4
-sphinxcontrib-htmlhelp==2.0.3
+sphinxcontrib-applehelp==1.0.7
+sphinxcontrib-devhelp==1.0.5
+sphinxcontrib-htmlhelp==2.0.4
 sphinxcontrib-httpdomain==1.8.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 sphinxcontrib-jquery==4.1; python_version >= '2.7'
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-openapi==0.7.0
 sphinxcontrib-plantuml==0.25
-sphinxcontrib-qthelp==1.0.5
-sphinxcontrib-serializinghtml==1.1.7
+sphinxcontrib-qthelp==1.0.6
+sphinxcontrib-serializinghtml==1.1.8
 stevedore==5.1.0; python_version >= '3.8'
 tomli==2.0.1; python_version < '3.11'
-tox==4.8.0
+tox==4.9.0
+typing-extensions==4.7.1; python_version >= '3.7'
 urllib3==2.0.4; python_version >= '3.7'
 virtualenv==20.24.3; python_version >= '3.7'
 voluptuous==0.13.1
@@ -104,11 +109,10 @@ pydantic==1.10.12; python_version >= '3.7'
 python-dateutil==2.8.2; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 python-jose==3.3.0
 python-multipart==0.0.6
-redis==4.6.0
+redis==5.0.0
 rsa==4.9; python_version >= '3.6' and python_version < '4'
-sqlalchemy==2.0.19
+sqlalchemy==2.0.20
 starlette==0.27.0; python_version >= '3.7'
-typing-extensions==4.7.1; python_version >= '3.7'
 tzdata==2023.3; python_version >= '2'
 uvicorn==0.23.2
 vine==5.0.0; python_version >= '3.6'

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ click-repl==0.3.0; python_version >= '3.6'
 configobj==5.0.8
 dynaconf==3.2.1
 ecdsa==0.18.0; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'
-exceptiongroup==1.1.2; python_version < '3.11'
+exceptiongroup==1.1.3; python_version < '3.11'
 fastapi==0.99.1
 greenlet==2.0.2; platform_machine == 'aarch64' or (platform_machine == 'ppc64le' or (platform_machine == 'x86_64' or (platform_machine == 'amd64' or (platform_machine == 'AMD64' or (platform_machine == 'win32' or platform_machine == 'WIN32')))))
 h11==0.14.0; python_version >= '3.7'
@@ -24,11 +24,11 @@ pydantic==1.10.12; python_version >= '3.7'
 python-dateutil==2.8.2; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 python-jose==3.3.0
 python-multipart==0.0.6
-redis==4.6.0
+redis==5.0.0
 rsa==4.9; python_version >= '3.6' and python_version < '4'
 six==1.16.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 sniffio==1.3.0; python_version >= '3.7'
-sqlalchemy==2.0.19
+sqlalchemy==2.0.20
 starlette==0.27.0; python_version >= '3.7'
 typing-extensions==4.7.1; python_version >= '3.7'
 tzdata==2023.3; python_version >= '2'

--- a/tests/bdd/features/tokens/generate.feature
+++ b/tests/bdd/features/tokens/generate.feature
@@ -1,0 +1,69 @@
+Feature: Generate HTTP token for Repository Service for TUF (RSTUF)
+    As an admin,
+    Admin has deployed and bootstrapped RSTUF
+
+
+    Scenario Outline: Admin uses HTTP API to generate a token
+        Given the admin has the admin password
+        And the admin gets an 'access_token' by logging in to '/api/v1/token' with a 'write:token' scope
+        And the admin adds Authorization Bearer 'access_token' in the 'headers'
+        And the admin adds JSON payload with scopes: <scopes> and expires: <expires>
+        When the admin sends a POST request to '/api/v1/token/new'
+        Then the admin should get status code '200'
+        And the admin should get 'access_token' with a new token
+
+        Examples:
+            | scopes                                           | expires |
+            | ['write:targets']                                | 1       |
+            | ['write:targets', 'read:settings']               | 240     |
+            | ['read:bootstrap']                               | 1       |
+            | ['read:bootstrap','write:targets']               | 24      |
+            | ['read:settings']                                | 3       |
+            | ['read:token']                                   | 5       |
+            | ['write:targets', 'read:settings', 'read:tasks'] | 380     |
+
+
+   Scenario Outline: Admin cannot generate Token using HTTP API with an invalid expires
+        Given the admin has the admin password
+        And the admin gets an 'access_token' by logging in to '/api/v1/token' with a 'write:token' scope
+        And the admin adds Authorization Bearer 'access_token' in the 'headers'
+        And the admin adds JSON payload with scopes: <scopes> and expires: <expires>
+        When the admin sends a POST request to '/api/v1/token/new' with invalid 'expires' in 'payload'
+        Then the admin should get status code '422'
+
+        Examples:
+            | scopes                             | expires |
+            | ['read:bootstrap','write:targets'] | 0       |
+            | ['read:bootstrap','write:targets'] | -5      |
+            | ['read:bootstrap']                 | None    |
+
+
+   Scenario Outline: Admin cannot generate Token using HTTP API for certain scopes
+        Given the admin has the admin password
+        And the admin gets an 'access_token' by logging in to '/api/v1/token' with a 'write:token' scope
+        And the admin adds Authorization Bearer 'access_token' in the 'headers'
+        And the admin adds JSON payload with scopes: <scopes> and expires: <expires>
+        When the admin sends a POST request to '/api/v1/token/new' with not allowed 'scopes' in 'payload'
+        Then the admin should get status code '422'
+
+        Examples:
+            | scopes                               | expires |
+            | ['write:token']                      | 24      |
+            | ['read:bootstrap','write:token']     | 24      |
+            | ['write:bootstrap']                  | 24      |
+            | ['write:bootstrap', 'read:settings'] | 24      |
+            | []                                   | 24      |
+            | ['']                                 | 24      |
+
+   Scenario Outline: Admin is Unauthorized to generate using HTTP API with an invalid token
+        Given the admin adds Authorization Bearer <token> in the 'headers'
+        And the admin adds JSON payload with scopes: <scopes> and expires: <expires>
+        When the admin sends a POST request to '/api/v1/token/new' with invalid 'access_token' in the headers
+        Then the admin should get status code '401'
+        And the admin should get 'Failed to validate token' in the body
+
+        Examples:
+            | token       | scopes             | expires |
+            | invalid     | ['write:targets']  | 1       |
+            | eyJhbiJIUzI | ['read:bootstrap'] | 1       |
+            | ''          | ['read:bootstrap'] | 1       |

--- a/tests/bdd/features/tokens/login.feature
+++ b/tests/bdd/features/tokens/login.feature
@@ -1,0 +1,52 @@
+Feature: Login to Repository Service for TUF (RSTUF) and receive an access token
+    As an admin,
+    Admin has deployed and bootstrapped RSTUF
+
+    Scenario Outline: Login using RSTUF API
+        Given the API requester prepares 'data' with <username>, <password>, <scope>, <expires>
+        When the API requester sends a 'POST' method to '/api/v1/token' with 'data'
+        Then the API requester should get status code '200'
+        And the API requester should get 'access_token' in response body
+
+        Examples:
+            | username | password      | scope                          | expires |
+            | admin    | secret        | read:bootstrap                 | None    |
+            | admin    | secret        | read:bootstrap write:bootstrap | None    |
+            | admin    | secret        | read:bootstrap read:settings   | None    |
+            | admin    | secret        | read:token                     | 240     |
+
+
+    Scenario Outline: Login using RSTUF API gets Unauthorized
+        Given the API requester prepares 'data' with <username>, <password>, <scope>, <expires>
+        When the API requester sends a 'POST' method to '/api/v1/token' with invalid username/password in 'data'
+        Then the API requester should get status code '401'
+        And the API requester should get 'detail: Unauthorized' in the response body
+
+        Examples:
+            | username | password      | scope             | expires |
+            | admin    | invalidpass   | write:bootstrap   | 1       |
+            | admin    | password-test | write:bootstrap   | 1       |
+            | admin    | test-assword  | write:bootstrap   | 1       |
+            | admin    | admin         | write:bootstrap   | 1       |
+            | admin    | ''            | write:bootstrap   | 1       |
+            | admin    | None          | write:bootstrap   | 1       |
+            | admin    | admin         | write:bootstrap   | 1       |
+            | root     | secret        | write:bootstrap   | 1       |
+            | root     | 123456        | write:bootstrap   | 1       |
+            | ''       | secret        | write:bootstrap   | 1       |
+            | None     | 123456        | write:bootstrap   | 1       |
+
+    Scenario Outline: Login using RSTUF API gets forbidden for invalid scopes
+        Given the API requester prepares 'data' with <username>, <password>, <scope>, <expires>
+        When the API requester sends a 'POST' method to '/api/v1/token' with invalid scopes in 'data'
+        Then the API requester should get status code '403'
+        And the API requester should get 'scope invalid' in the response body
+
+        Examples:
+            | username | password      | scope             | expires |
+            | admin    | secret        | invalid           | 1       |
+            | admin    | secret        | root              | 1       |
+            | admin    | secret        | all:all           | 1       |
+            | admin    | secret        | read-write:token  | 1       |
+            | admin    | secret        | ''                | 1       |
+            | admin    | secret        | None              | 1       |

--- a/tests/bdd/tokens/__init__.py
+++ b/tests/bdd/tokens/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2022-2023 VMware Inc
+#
+# SPDX-License-Identifier: MIT

--- a/tests/bdd/tokens/test_generate.py
+++ b/tests/bdd/tokens/test_generate.py
@@ -1,0 +1,169 @@
+# SPDX-FileCopyrightText: 2022-2023 VMware Inc
+#
+# SPDX-License-Identifier: MIT
+import ast
+
+from pytest_bdd import given, scenario, then, when
+from pytest_bdd.parsers import parse
+
+
+@scenario(
+    "../features/tokens/generate.feature",
+    "Admin uses HTTP API to generate a token",
+)
+def test_admin_uses_http_api_to_generate_a_token():
+    """Admin uses HTTP API to generate a token."""
+
+
+@given("the admin has the admin password", target_fixture="admin_passwd")
+def the_admin_has_the_admin_password(get_admin_pwd):
+    return get_admin_pwd
+
+
+@given(
+    "the admin gets an 'access_token' by logging in to '/api/v1/token' with a "
+    "'write:token' scope",
+    target_fixture="access_token",
+)
+def the_admin_has_generated_an_access_token_with_write_token(access_token):
+    return access_token
+
+
+@given(
+    parse("the admin adds Authorization Bearer {token} in the 'headers'"),
+    target_fixture="headers",
+)
+def the_admin_adds_authorization_token_in_the_headers(access_token, token):
+    if token == "'access_token'":
+        header_token = f"Bearer {access_token}"
+    else:
+        header_token = f"Bearer {token}"
+    headers = {"Authorization": header_token}
+    return headers
+
+
+@given(
+    parse(
+        "the admin adds JSON payload with scopes: {scopes} and "
+        "expires: {expires}"
+    ),
+    target_fixture="payload",
+)
+def the_admin_adds_payload(scopes, expires):
+    if scopes == "None":
+        scopes = None
+        payload = {"scopes": scopes, "expires": expires}
+    else:
+        # convert list string "['str', 'str']" to python list['str', 'str']
+        payload = {"scopes": ast.literal_eval(scopes), "expires": expires}
+
+    return payload
+
+
+@when(
+    "the admin sends a POST request to '/api/v1/token/new'",
+    target_fixture="response",
+)
+def the_admin_sends_request(test_client, headers, payload):
+    response = test_client.post(
+        url="/api/v1/token/new", headers=headers, json=payload
+    )
+    return response
+
+
+@then("the admin should get status code '200'")
+def the_admin_gets_status_code_200(response):
+    assert response.status_code == 200, response.text
+
+
+@then("the admin should get 'access_token' with a new token")
+def the_admin_gets_access_token(response):
+    assert response.json()["access_token"] is not None
+
+
+@scenario(
+    "../features/tokens/generate.feature",
+    "Admin cannot generate Token using HTTP API with an invalid expires",
+)
+def test_admin_cannot_generate_token_using_api_with_invalid_expires():
+    """Admin cannot generate Token using HTTP API with an invalid expires"""
+
+
+@when(
+    "the admin sends a POST request to '/api/v1/token/new' with invalid "
+    "'expires' in 'payload'",
+    target_fixture="response",
+)
+def the_admin_sends_with_invalid_expires_in_payload(
+    test_client, headers, payload
+):
+    response = test_client.post(
+        url="/api/v1/token/new", headers=headers, json=payload
+    )
+    return response
+
+
+@then("the admin should get status code '422'")
+def the_admin_should_get_status_code_422_invalid_expires(response):
+    assert response.status_code == 422, response.text
+
+
+@scenario(
+    "../features/tokens/generate.feature",
+    "Admin cannot generate Token using HTTP API for certain scopes",
+)
+def test_admin_cannot_generate_token_using_http_rest_api_for_certain_scopes():
+    """Admin cannot generate Token using HTTP API for certain scopes."""
+
+
+@when(
+    "the admin sends a POST request to '/api/v1/token/new' with not allowed "
+    "'scopes' in 'payload'",
+    target_fixture="response",
+)
+def the_admin_sends_request_with_invalid_scopes(test_client, headers, payload):
+    response = test_client.post(
+        url="/api/v1/token/new", headers=headers, json=payload
+    )
+    return response
+
+
+@then("the admin should get status code '422'")
+def the_admin_should_get_status_code_422_scopes(response):
+    assert response.status_code == 422, response.text
+
+
+@scenario(
+    "../features/tokens/generate.feature",
+    "Admin is Unauthorized to generate using HTTP API with an invalid token",
+)
+def test_admin_is_unauthorized_to_generate_invalid_token():
+    """
+    Admin is Unauthorized to generate using HTTP API with an invalid token.
+    """
+
+
+@when(
+    "the admin sends a POST request to '/api/v1/token/new' with invalid "
+    "'access_token' in the headers",
+    target_fixture="response",
+)
+def the_admin_sends_a_invalid_access_token_in_headers(
+    test_client, headers, payload
+):
+    response = test_client.post(
+        url="/api/v1/token/new",
+        headers=headers,
+        json=payload,
+    )
+    return response
+
+
+@then("the admin should get status code '401'")
+def the_admin_should_get_status_code_401(response):
+    assert response.status_code == 401, response.text
+
+
+@then("the admin should get 'Failed to validate token' in the body")
+def the_admin_should_get_failed_to_validate_token(response):
+    assert response.json()["detail"]["error"] == "Failed to validate token"

--- a/tests/bdd/tokens/test_login.py
+++ b/tests/bdd/tokens/test_login.py
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: 2022-2023 VMware Inc
+#
+# SPDX-License-Identifier: MIT
+from pytest_bdd import given, scenario, then, when
+from pytest_bdd.parsers import parse
+
+
+@scenario("../features/tokens/login.feature", "Login using RSTUF API")
+def test_login_using_rstuf_api():
+    """Login using RSTUF API."""
+
+
+@given(
+    parse(
+        "the API requester prepares 'data' with {username}, {password},"
+        "{scope}, {expires}"
+    ),
+    target_fixture="data",
+)
+def the_api_requester_prepares_data(username, password, scope, expires):
+    if expires == "None":
+        expires = None
+    else:
+        expires = int(expires)
+
+    return {
+        "username": username,
+        "password": password,
+        "scope": scope,
+        "expires": expires,
+    }
+
+
+@when(
+    "the API requester sends a 'POST' method to '/api/v1/token' with 'data'",
+    target_fixture="response",
+)
+def the_api_requester_sends_data(data, test_client):
+    return test_client.post(url="/api/v1/token", data=data)
+
+
+@then("the API requester should get status code '200'")
+def the_api_requester_should_get_status_code_200(response):
+    assert response.status_code == 200
+
+
+@then("the API requester should get 'access_token' in response body")
+def the_api_requester_should_get_access_token_in_response_body(response):
+    assert response.json()["access_token"] is not None
+
+
+@scenario(
+    "../features/tokens/login.feature",
+    "Login using RSTUF API gets Unauthorized",
+)
+def test_login_using_rstuf_api_gets_unauthorized():
+    """Login using RSTUF API gets Unauthorized."""
+
+
+@when(
+    "the API requester sends a 'POST' method to '/api/v1/token' with invalid "
+    "username/password in 'data'",
+    target_fixture="unauthorized_response",
+)
+def the_api_requester_sends_data_unauthorized(data, test_client):
+    return test_client.post(url="/api/v1/token", data=data)
+
+
+@then("the API requester should get status code '401'")
+def the_api_requester_should_get_status_code_401(unauthorized_response):
+    assert unauthorized_response.status_code == 401
+
+
+@then(
+    "the API requester should get 'detail: Unauthorized' in the response body"
+)
+def the_api_requester_should_get_detail_unauthorized_in_the_response_body(
+    unauthorized_response,
+):
+    assert unauthorized_response.json()["detail"] == "Unauthorized"
+
+
+@scenario(
+    "../features/tokens/login.feature",
+    "Login using RSTUF API gets forbidden for invalid scopes",
+)
+def test_login_using_rstuf_api_gets_forbidden_for_invalid_scopes():
+    """Login using RSTUF API gets forbidden for invalid scopes."""
+
+
+@when(
+    "the API requester sends a 'POST' method to '/api/v1/token' with invalid "
+    "scopes in 'data'",
+    target_fixture="invalid_scope_response",
+)
+def the_api_requester_sends_invalid_scopes_in_data(data, test_client):
+    return test_client.post(url="/api/v1/token", data=data)
+
+
+@then("the API requester should get status code '403'")
+def the_api_requester_should_get_status_code_403(invalid_scope_response):
+    assert invalid_scope_response.status_code == 403
+
+
+@then("the API requester should get 'scope invalid' in the response body")
+def the_api_requester_should_get_scope_invalid_in_the_response_body(
+    invalid_scope_response,
+):
+    assert "forbidden" in invalid_scope_response.json()["detail"]["error"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2022-2023 VMware Inc
 #
 # SPDX-License-Identifier: MIT
-
+import os
 from dataclasses import dataclass
 from typing import List
 
@@ -60,3 +60,21 @@ def test_db():
         scopes: List[Scope]
 
     return (User, Scope)
+
+
+@pytest.fixture()
+def get_admin_pwd():
+    return os.getenv("SECRETS_RSTUF_ADMIN_PASSWORD")
+
+
+@pytest.fixture()
+def access_token(test_client):
+    data = {
+        "username": "admin",
+        "password": "secret",
+        "scope": "write:token read:tasks write:targets delete:targets",
+        "expires": 1,
+    }
+    response = test_client.post("/api/v1/token", data=data)
+
+    return response.json()["access_token"]

--- a/tox.ini
+++ b/tox.ini
@@ -53,10 +53,10 @@ commands =
 
 [testenv:test]
 commands =
-    coverage run --omit='tests/*' -m pytest tests/unit/ --gherkin-terminal-reporter -vv
-    pytest tests/bdd/ --gherkin-terminal-reporter -vv
+    coverage run --omit='tests/*' -m pytest tests/unit/ -vv
     coverage xml -i
     coverage report
+    pytest tests/bdd/ --gherkin-terminal-reporter -vv
 
 [testenv:requirements]
 description="Check if `make requirements` is up-to-date."

--- a/tox.ini
+++ b/tox.ini
@@ -53,7 +53,8 @@ commands =
 
 [testenv:test]
 commands =
-    coverage run --omit='tests/*' -m pytest -vv
+    coverage run --omit='tests/*' -m pytest tests/unit/ --gherkin-terminal-reporter -vv
+    pytest tests/bdd/ --gherkin-terminal-reporter -vv
     coverage xml -i
     coverage report
 


### PR DESCRIPTION
The current BDD Tokens tests are part of integration tests in the RSTUF umbrella repository.
This BDD feature test doesn't belong to the integration tests once API Token authentication/authorization (auth) feature is a single component.

The BDD test is still valid once it describes very well the expected behavior.

This commit adds the test to the API and is part of the https://github.com/repository-service-tuf/repository-service-tuf/issues/41

Closes #281