### PR TITLE
Fix: protection during bootstrap process

### DIFF
--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -856,6 +856,10 @@
                     "bootstrap": {
                         "type": "boolean",
                         "title": "Bootstrap"
+                    },
+                    "state": {
+                        "type": "string",
+                        "title": "State"
                     }
                 },
                 "type": "object",

--- a/repository_service_tuf_api/__init__.py
+++ b/repository_service_tuf_api/__init__.py
@@ -226,6 +226,7 @@ def bootstrap_state() -> BootstrapState:
         return bootstrap_state
 
     if len(bootstrap.split("-")) == 1:
+        # This is a finished bootstrap. It only contains the `<task-id>``
         bootstrap_state.bootstrap = True
         bootstrap_state.state = "finished"
         bootstrap_state.task_id = bootstrap
@@ -233,6 +234,8 @@ def bootstrap_state() -> BootstrapState:
         return bootstrap_state
 
     elif len(bootstrap.split("-")) == 2:
+        # This is considered an intermediated state It is not finished because
+        # there is a `<state>-`
         bootstrap_state.bootstrap = False
         bootstrap_state.state = bootstrap.split("-")[0]
         bootstrap_state.task_id = bootstrap.split("-")[1]

--- a/repository_service_tuf_api/config.py
+++ b/repository_service_tuf_api/config.py
@@ -9,8 +9,8 @@ from fastapi import HTTPException, status
 from pydantic import BaseModel
 
 from repository_service_tuf_api import (
+    bootstrap_state,
     get_task_id,
-    is_bootstrap_done,
     repository_metadata,
     settings_repository,
 )
@@ -70,10 +70,14 @@ class PutPayload(BaseModel):
 
 
 def put(payload: PutPayload):
-    if is_bootstrap_done() is False:
+    bs_state = bootstrap_state()
+    if bs_state.bootstrap is False:
         raise HTTPException(
             status.HTTP_404_NOT_FOUND,
-            detail={"error": "System has no repository metadata"},
+            detail={
+                "message": "No Repository Settings/Config found.",
+                "error": f"It requires bootstrap. State: {bs_state.state}",
+            },
         )
 
     task_id = get_task_id()
@@ -93,10 +97,14 @@ def put(payload: PutPayload):
 
 
 def get():
-    if is_bootstrap_done() is False:
+    bs_state = bootstrap_state()
+    if bs_state.bootstrap is False:
         raise HTTPException(
             status.HTTP_404_NOT_FOUND,
-            detail={"error": "System has no repository metadata"},
+            detail={
+                "message": "No Repository Settings/Config found.",
+                "error": f"It requires bootstrap. State: {bs_state.state}",
+            },
         )
 
     # Forces all values to be refreshed

--- a/repository_service_tuf_api/targets.py
+++ b/repository_service_tuf_api/targets.py
@@ -10,8 +10,8 @@ from fastapi import HTTPException, status
 from pydantic import BaseModel, Field
 
 from repository_service_tuf_api import (
+    bootstrap_state,
     get_task_id,
-    is_bootstrap_done,
     repository_metadata,
 )
 
@@ -110,10 +110,16 @@ def post(payload: AddPayload) -> Response:
     It generates a new task id, syncs with the Redis server, and posts the new
     task.
     """
-    if is_bootstrap_done() is False:
+    bs_state = bootstrap_state()
+    if bs_state.bootstrap is False:
         raise HTTPException(
             status.HTTP_200_OK,
-            detail={"error": "System has not a Repository Metadata"},
+            detail={
+                "message": "Task not accepted.",
+                "error": (
+                    f"It requires bootstrap finished. State: {bs_state.state}"
+                ),
+            },
         )
 
     task_id = get_task_id()
@@ -162,10 +168,16 @@ def delete(payload: DeletePayload) -> Response:
     It generates a new task id, syncs with the Redis server, and posts the new
     task.
     """
-    if is_bootstrap_done() is False:
+    bs_state = bootstrap_state()
+    if bs_state.bootstrap is False:
         raise HTTPException(
             status.HTTP_200_OK,
-            detail={"error": "System has not a Repository Metadata"},
+            detail={
+                "message": "Task not accepted.",
+                "error": (
+                    f"It requires bootstrap finished. State: {bs_state.state}"
+                ),
+            },
         )
 
     task_id = get_task_id()

--- a/tests/unit/api/test_config.py
+++ b/tests/unit/api/test_config.py
@@ -16,10 +16,13 @@ class TestPutSettings:
             f_data = f.read()
 
         payload = json.loads(f_data)
-        mocked_check_metadata = pretend.call_recorder(lambda: True)
+
+        mocked_bootstrap_state = pretend.call_recorder(
+            lambda *a: pretend.stub(bootstrap=True)
+        )
         monkeypatch.setattr(
-            "repository_service_tuf_api.config.is_bootstrap_done",
-            mocked_check_metadata,
+            "repository_service_tuf_api.config.bootstrap_state",
+            mocked_bootstrap_state,
         )
         mocked_get_task_id = pretend.call_recorder(lambda: "task-id")
         monkeypatch.setattr(
@@ -34,7 +37,7 @@ class TestPutSettings:
         )
         response = test_client.put(URL, json=payload, headers=token_headers)
         assert response.status_code == status.HTTP_202_ACCEPTED
-        assert mocked_check_metadata.calls == [pretend.call()]
+        assert mocked_bootstrap_state.calls == [pretend.call()]
         assert mocked_get_task_id.calls == [pretend.call()]
         assert mocked_repository_metadata.apply_async.calls == [
             pretend.call(
@@ -52,31 +55,64 @@ class TestPutSettings:
             f_data = f.read()
 
         payload = json.loads(f_data)
-        mocked_check_metadata = pretend.call_recorder(lambda: False)
+        mocked_bootstrap_state = pretend.call_recorder(
+            lambda *a: pretend.stub(bootstrap=False, state=None)
+        )
         monkeypatch.setattr(
-            "repository_service_tuf_api.config.is_bootstrap_done",
-            mocked_check_metadata,
+            "repository_service_tuf_api.config.bootstrap_state",
+            mocked_bootstrap_state,
         )
         response = test_client.put(URL, json=payload, headers=token_headers)
         assert response.status_code == status.HTTP_404_NOT_FOUND
-        assert (
-            response.json().get("detail").get("error")
-            == "System has no repository metadata"
+        assert response.json() == {
+            "detail": {
+                "message": "No Repository Settings/Config found.",
+                "error": "It requires bootstrap. State: None",
+            }
+        }
+        assert mocked_bootstrap_state.calls == [pretend.call()]
+
+    def test_put_settings_intermediate_state(
+        self, test_client, token_headers, monkeypatch
+    ):
+        with open("tests/data_examples/config/update_settings.json") as f:
+            f_data = f.read()
+
+        payload = json.loads(f_data)
+        mocked_bootstrap_state = pretend.call_recorder(
+            lambda *a: pretend.stub(bootstrap=False, state="signing")
         )
+        monkeypatch.setattr(
+            "repository_service_tuf_api.config.bootstrap_state",
+            mocked_bootstrap_state,
+        )
+        response = test_client.put(URL, json=payload, headers=token_headers)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert response.json() == {
+            "detail": {
+                "message": "No Repository Settings/Config found.",
+                "error": "It requires bootstrap. State: signing",
+            }
+        }
+
+        assert mocked_bootstrap_state.calls == [pretend.call()]
 
 
 class TestGetSettings:
     def test_get_settings(self, test_client, token_headers, monkeypatch):
-        mocked_check_metadata = pretend.call_recorder(lambda: True)
-        monkeypatch.setattr(
-            "repository_service_tuf_api.config.is_bootstrap_done",
-            mocked_check_metadata,
-        )
+        url = "/api/v1/config"
 
+        mocked_bootstrap_state = pretend.call_recorder(
+            lambda *a: pretend.stub(bootstrap=True)
+        )
+        monkeypatch.setattr(
+            "repository_service_tuf_api.config.bootstrap_state",
+            mocked_bootstrap_state,
+        )
         fake_settings = pretend.stub(
             fresh=pretend.call_recorder(lambda: None),
             to_dict=pretend.call_recorder(
-                lambda: {"k": "v", "j": ["v1", "v2"]}
+                lambda: {"k": "v", "j": ["v1", "v2"], "l": "none"}
             ),
         )
         monkeypatch.setattr(
@@ -84,32 +120,41 @@ class TestGetSettings:
             fake_settings,
         )
 
-        test_response = test_client.get(URL, headers=token_headers)
+        test_response = test_client.get(url, headers=token_headers)
         assert test_response.status_code == status.HTTP_200_OK
+        assert test_response.json() == {
+            "data": {"k": "v", "j": ["v1", "v2"]},
+            "message": "Current Settings",
+        }
+        assert mocked_bootstrap_state.calls == [pretend.call()]
         assert fake_settings.fresh.calls == [pretend.call()]
+        assert fake_settings.to_dict.calls == [pretend.call()]
 
     def test_get_settings_without_bootstrap(
         self, test_client, token_headers, monkeypatch
     ):
-        mocked_check_metadata = pretend.call_recorder(lambda: False)
+        url = "/api/v1/config"
+
+        mocked_bootstrap_state = pretend.call_recorder(
+            lambda *a: pretend.stub(bootstrap=False, state="None")
+        )
         monkeypatch.setattr(
-            "repository_service_tuf_api.config.is_bootstrap_done",
-            mocked_check_metadata,
+            "repository_service_tuf_api.config.bootstrap_state",
+            mocked_bootstrap_state,
         )
 
-        test_response = test_client.get(URL, headers=token_headers)
+        test_response = test_client.get(url, headers=token_headers)
         assert test_response.status_code == status.HTTP_404_NOT_FOUND
-        assert (
-            test_response.json().get("detail").get("error")
-            == "System has no repository metadata"
-        )
+        assert test_response.json() == {
+            "detail": {
+                "message": "No Repository Settings/Config found.",
+                "error": "It requires bootstrap. State: None",
+            }
+        }
+        assert mocked_bootstrap_state.calls == [pretend.call()]
 
     def test_get_settings_invalid_token(self, test_client, monkeypatch):
-        mocked_check_metadata = pretend.call_recorder(lambda: True)
-        monkeypatch.setattr(
-            "repository_service_tuf_api.config.is_bootstrap_done",
-            mocked_check_metadata,
-        )
+        url = "/api/v1/config"
 
         def fake_get(arg):
             if "_EXPIRATION" in arg:
@@ -138,7 +183,7 @@ class TestGetSettings:
         )
         token_headers = {"Authorization": "Bearer h4ck3r"}
 
-        test_response = test_client.get(URL, headers=token_headers)
+        test_response = test_client.get(url, headers=token_headers)
         assert test_response.status_code == status.HTTP_401_UNAUTHORIZED
         assert test_response.json() == {
             "detail": {"error": "Failed to validate token"}

--- a/tests/unit/api/test_targets.py
+++ b/tests/unit/api/test_targets.py
@@ -17,12 +17,15 @@ class TestPostTargets:
 
         payload = json.loads(f_data)
 
-        mocked_repository_metadata = pretend.stub(
-            apply_async=pretend.call_recorder(lambda **kw: None)
+        mocked_bootstrap_state = pretend.call_recorder(
+            lambda *a: pretend.stub(bootstrap=True)
         )
         monkeypatch.setattr(
-            "repository_service_tuf_api.targets.is_bootstrap_done",
-            lambda: True,
+            "repository_service_tuf_api.targets.bootstrap_state",
+            mocked_bootstrap_state,
+        )
+        mocked_repository_metadata = pretend.stub(
+            apply_async=pretend.call_recorder(lambda **kw: None)
         )
         monkeypatch.setattr(
             "repository_service_tuf_api.targets.repository_metadata",
@@ -50,6 +53,7 @@ class TestPostTargets:
             },
             "message": "Target(s) successfully submitted.",
         }
+        assert mocked_bootstrap_state.calls == [pretend.call()]
         assert mocked_repository_metadata.apply_async.calls == [
             pretend.call(
                 kwargs={
@@ -75,12 +79,15 @@ class TestPostTargets:
 
         payload = json.loads(f_data)
 
-        mocked_repository_metadata = pretend.stub(
-            apply_async=pretend.call_recorder(lambda **kw: None)
+        mocked_bootstrap_state = pretend.call_recorder(
+            lambda *a: pretend.stub(bootstrap=True)
         )
         monkeypatch.setattr(
-            "repository_service_tuf_api.targets.is_bootstrap_done",
-            lambda: True,
+            "repository_service_tuf_api.targets.bootstrap_state",
+            mocked_bootstrap_state,
+        )
+        mocked_repository_metadata = pretend.stub(
+            apply_async=pretend.call_recorder(lambda **kw: None)
         )
         monkeypatch.setattr(
             "repository_service_tuf_api.targets.repository_metadata",
@@ -124,6 +131,7 @@ class TestPostTargets:
                 **target["info"]["custom"],
             }
 
+        assert mocked_bootstrap_state.calls == [pretend.call()]
         assert mocked_repository_metadata.apply_async.calls == [
             pretend.call(
                 kwargs={
@@ -151,9 +159,12 @@ class TestPostTargets:
         # Disable publish_targets
         payload["publish_targets"] = False
 
+        mocked_bootstrap_state = pretend.call_recorder(
+            lambda *a: pretend.stub(bootstrap=True)
+        )
         monkeypatch.setattr(
-            "repository_service_tuf_api.targets.is_bootstrap_done",
-            lambda: True,
+            "repository_service_tuf_api.targets.bootstrap_state",
+            mocked_bootstrap_state,
         )
         fake_task_id = uuid4().hex
         monkeypatch.setattr(
@@ -185,6 +196,7 @@ class TestPostTargets:
             },
             "message": msg,
         }
+        assert mocked_bootstrap_state.calls == [pretend.call()]
         assert mocked_repository_metadata.apply_async.calls == [
             pretend.call(
                 kwargs={
@@ -204,16 +216,52 @@ class TestPostTargets:
         with open("tests/data_examples/targets/payload.json") as f:
             f_data = f.read()
 
-        payload = json.loads(f_data)
-        monkeypatch.setattr(
-            "repository_service_tuf_api.targets.is_bootstrap_done",
-            lambda: False,
+        mocked_bootstrap_state = pretend.call_recorder(
+            lambda *a: pretend.stub(bootstrap=False, state=None)
         )
+        monkeypatch.setattr(
+            "repository_service_tuf_api.targets.bootstrap_state",
+            mocked_bootstrap_state,
+        )
+
+        payload = json.loads(f_data)
+
         response = test_client.post(url, json=payload, headers=token_headers)
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == {
-            "detail": {"error": "System has not a Repository Metadata"}
+            "detail": {
+                "message": "Task not accepted.",
+                "error": "It requires bootstrap finished. State: None",
+            }
         }
+        assert mocked_bootstrap_state.calls == [pretend.call()]
+
+    def test_post_with_bootstrap_intermediate_state(
+        self, monkeypatch, test_client, token_headers
+    ):
+        url = "/api/v1/targets/"
+        with open("tests/data_examples/targets/payload.json") as f:
+            f_data = f.read()
+
+        mocked_bootstrap_state = pretend.call_recorder(
+            lambda *a: pretend.stub(bootstrap=False, state="signing")
+        )
+        monkeypatch.setattr(
+            "repository_service_tuf_api.targets.bootstrap_state",
+            mocked_bootstrap_state,
+        )
+
+        payload = json.loads(f_data)
+
+        response = test_client.post(url, json=payload, headers=token_headers)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == {
+            "detail": {
+                "message": "Task not accepted.",
+                "error": "It requires bootstrap finished. State: signing",
+            }
+        }
+        assert mocked_bootstrap_state.calls == [pretend.call()]
 
     def test_post_missing_required_field(self, test_client, token_headers):
         url = "/api/v1/targets/"
@@ -279,9 +327,12 @@ class TestDeleteTargets:
             "targets": ["file-v1.0.0_i683.tar.gz", "v0.4.1/file.tar.gz"],
         }
 
+        mocked_bootstrap_state = pretend.call_recorder(
+            lambda *a: pretend.stub(bootstrap=True)
+        )
         monkeypatch.setattr(
-            "repository_service_tuf_api.targets.is_bootstrap_done",
-            lambda: True,
+            "repository_service_tuf_api.targets.bootstrap_state",
+            mocked_bootstrap_state,
         )
         mocked_repository_metadata = pretend.stub(
             apply_async=pretend.call_recorder(lambda **kw: None)
@@ -317,6 +368,7 @@ class TestDeleteTargets:
             },
             "message": "Remove Target(s) successfully submitted.",
         }
+        assert mocked_bootstrap_state.calls == [pretend.call()]
         assert mocked_repository_metadata.apply_async.calls == [
             pretend.call(
                 kwargs={
@@ -339,9 +391,12 @@ class TestDeleteTargets:
             "publish_targets": False,
         }
 
+        mocked_bootstrap_state = pretend.call_recorder(
+            lambda *a: pretend.stub(bootstrap=True)
+        )
         monkeypatch.setattr(
-            "repository_service_tuf_api.targets.is_bootstrap_done",
-            lambda: True,
+            "repository_service_tuf_api.targets.bootstrap_state",
+            mocked_bootstrap_state,
         )
         mocked_repository_metadata = pretend.stub(
             apply_async=pretend.call_recorder(lambda **kw: None)
@@ -381,6 +436,7 @@ class TestDeleteTargets:
             },
             "message": msg,
         }
+        assert mocked_bootstrap_state.calls == [pretend.call()]
         assert mocked_repository_metadata.apply_async.calls == [
             pretend.call(
                 kwargs={
@@ -401,9 +457,12 @@ class TestDeleteTargets:
         payload = {
             "targets": ["file-v1.0.0_i683.tar.gz", "v0.4.1/file.tar.gz"]
         }
+        mocked_bootstrap_state = pretend.call_recorder(
+            lambda *a: pretend.stub(bootstrap=False, state=None)
+        )
         monkeypatch.setattr(
-            "repository_service_tuf_api.targets.is_bootstrap_done",
-            lambda: False,
+            "repository_service_tuf_api.targets.bootstrap_state",
+            mocked_bootstrap_state,
         )
         # https://github.com/tiangolo/fastapi/issues/5649
         response = test_client.request(
@@ -412,7 +471,39 @@ class TestDeleteTargets:
 
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == {
-            "detail": {"error": "System has not a Repository Metadata"}
+            "detail": {
+                "message": "Task not accepted.",
+                "error": "It requires bootstrap finished. State: None",
+            }
+        }
+        assert mocked_bootstrap_state.calls == [pretend.call()]
+
+    def test_delete_with_bootstrap_intermediate_state(
+        self, monkeypatch, test_client, token_headers
+    ):
+        url = "/api/v1/targets/"
+
+        payload = {
+            "targets": ["file-v1.0.0_i683.tar.gz", "v0.4.1/file.tar.gz"]
+        }
+        mocked_bootstrap_state = pretend.call_recorder(
+            lambda *a: pretend.stub(bootstrap=False, state="signing")
+        )
+        monkeypatch.setattr(
+            "repository_service_tuf_api.targets.bootstrap_state",
+            mocked_bootstrap_state,
+        )
+        # https://github.com/tiangolo/fastapi/issues/5649
+        response = test_client.request(
+            "DELETE", url, json=payload, headers=token_headers
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == {
+            "detail": {
+                "message": "Task not accepted.",
+                "error": "It requires bootstrap finished. State: signing",
+            }
         }
 
     def test_delete_missing_required_field(self, test_client, token_headers):

--- a/tests/unit/tuf_repository_service_api/test__init__.py
+++ b/tests/unit/tuf_repository_service_api/test__init__.py
@@ -39,7 +39,7 @@ class TestInit:
             pretend.call(fake_settings, {"BOOTSTRAP": None})
         ]
 
-    def test_get_bootstrap_state(self):
+    def test_bootstrap_state(self):
         repository_service_tuf_api.settings_repository = pretend.stub(
             reload=pretend.call_recorder(lambda: None),
             get_fresh=pretend.call_recorder(lambda *a: None),
@@ -49,7 +49,17 @@ class TestInit:
             False, None, None
         )
 
-    def test_get_bootstrap_state_signing(self):
+    def test_bootstrap_state_pre(self):
+        repository_service_tuf_api.settings_repository = pretend.stub(
+            reload=pretend.call_recorder(lambda: None),
+            get_fresh=pretend.call_recorder(lambda *a: "pre-<task_id>"),
+        )
+        result = repository_service_tuf_api.bootstrap_state()
+        assert result == repository_service_tuf_api.BootstrapState(
+            False, "pre", "<task_id>"
+        )
+
+    def test_bootstrap_state_signing(self):
         repository_service_tuf_api.settings_repository = pretend.stub(
             reload=pretend.call_recorder(lambda: None),
             get_fresh=pretend.call_recorder(lambda *a: "signing-<task_id>"),
@@ -59,7 +69,7 @@ class TestInit:
             False, "signing", "<task_id>"
         )
 
-    def test_get_bootstrap_state_finished(self):
+    def test_bootstrap_state_finished(self):
         repository_service_tuf_api.settings_repository = pretend.stub(
             reload=pretend.call_recorder(lambda: None),
             get_fresh=pretend.call_recorder(lambda *a: "<task_id>"),


### PR DESCRIPTION

The checks now are aligned with the Repository Settings `BOOTSTRAP` as mentioned in https://repository-service-tuf.readthedocs.io/en/stable/devel/design.html#rstuf-repository-settings-configuration

This change considers the bootstrap `pre` lock done by the RSTUF API and avoids the user can start adding/removing targets before the process finishes.

<!--- Thanks for taking the time to fill out this pull request! -->
<!--- Please fill in the fields below to submit a pull request. 
The more information provided, the better. -->

<!---  -->

# Description
<!--- What is the PR about? -->


<!--- Please reference the issue(s) this PR fixes. -->
Fixes #342


# Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)


# Additional requirements
- [X] Tests have been added for the bug fix or new feature
- [X] Docs have been added for the bug fix or new feature


# Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.rst).

- [X] I agree to follow this project's Code of Conduct