### PR TITLE
feat: bootstrap distributed async sign

### DIFF
--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -227,6 +227,90 @@
                 ]
             }
         },
+        "/api/v1/metadata/sign": {
+            "get": {
+                "tags": [
+                    "v1",
+                    "v1"
+                ],
+                "summary": "Get the role metadata signing data. Scope: write:metadata",
+                "description": "Get signing the role metadata signging status and current metadata.",
+                "operationId": "get_sign_api_v1_metadata_sign_get",
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetadataSignGetResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found"
+                    }
+                },
+                "security": [
+                    {
+                        "OAuth2PasswordBearer": [
+                            "write:metadata"
+                        ]
+                    }
+                ]
+            },
+            "post": {
+                "tags": [
+                    "v1",
+                    "v1"
+                ],
+                "summary": "Get the role metadata signing data. Scope: write:metadata",
+                "description": "Get signing the role metadata signging status and current metadata.",
+                "operationId": "post_sign_api_v1_metadata_sign_post",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetadataSignPostPayload"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "202": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetadataPostResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "OAuth2PasswordBearer": [
+                            "write:metadata"
+                        ]
+                    }
+                ]
+            }
+        },
         "/api/v1/artifacts/": {
             "post": {
                 "tags": [
@@ -808,7 +892,7 @@
             "BootstrapGetResponse": {
                 "properties": {
                     "data": {
-                        "$ref": "#/components/schemas/GetData"
+                        "$ref": "#/components/schemas/repository_service_tuf_api__bootstrap__GetData"
                     },
                     "message": {
                         "type": "string",
@@ -991,23 +1075,6 @@
                     ]
                 }
             },
-            "GetData": {
-                "properties": {
-                    "bootstrap": {
-                        "type": "boolean",
-                        "title": "Bootstrap"
-                    },
-                    "state": {
-                        "type": "string",
-                        "title": "State"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "bootstrap"
-                ],
-                "title": "GetData"
-            },
             "GetTokenResponse": {
                 "properties": {
                     "data": {
@@ -1182,8 +1249,139 @@
                     "data": {
                         "task_id": "7a634b556f784ae88785d36425f9a218"
                     },
-                    "message": "Bootstrap accepted."
+                    "message": "Metadata Update accepted."
                 }
+            },
+            "MetadataSignGetResponse": {
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/repository_service_tuf_api__metadata__GetData"
+                    },
+                    "message": {
+                        "type": "string",
+                        "title": "Message"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "message"
+                ],
+                "title": "MetadataSignGetResponse",
+                "example": {
+                    "metadata": {
+                        "root": {
+                            "signatures": [
+                                {
+                                    "keyid": "1cebe343e35f0213f6136758e6c3a8f8e1f9eeb7e47a07d5cb336462ed31dcb7",
+                                    "sig": "b3c81b6579442b8672ff460ac36cdb51064109fcfa93f0e72dabbf338f7d0c24e1a91d3696d72d81f60e94b2782ab1bf41e6b8f3e535538216f4379bf30a4302"
+                                },
+                                {
+                                    "keyid": "800dfb5a1982b82b7893e58035e19f414f553fc08cbb1130cfbae302a7b7fee5",
+                                    "sig": "fdfbb1877da404504e8b9c111d87680df5291094dafa01f66bfe6031e470d7c63cc477c1e79210a89e27734758e54fb54adc529918b1211d9dd9971c8bb26c0a"
+                                }
+                            ],
+                            "signed": {
+                                "_type": "root",
+                                "version": 1,
+                                "spec_version": "1.0.30",
+                                "expires": "2024-02-17T10:55:28Z",
+                                "consistent_snapshot": true,
+                                "keys": {
+                                    "f7a6872f297634219a80141caa2ec9ae8802098b07b67963272603e36cc19fd8": {
+                                        "keytype": "ed25519",
+                                        "scheme": "ed25519",
+                                        "keyval": {
+                                            "public": "9fe7ddccb75b977a041424a1fdc142e01be4abab918dc4c611fbfe4a3360a9a8"
+                                        }
+                                    },
+                                    "1cebe343e35f0213f6136758e6c3a8f8e1f9eeb7e47a07d5cb336462ed31dcb7": {
+                                        "keytype": "ed25519",
+                                        "scheme": "ed25519",
+                                        "keyval": {
+                                            "public": "ad1709b3cb419b99c5cd7427d6411522e5a93aec6767453e91af921a73d22a3c"
+                                        }
+                                    },
+                                    "800dfb5a1982b82b7893e58035e19f414f553fc08cbb1130cfbae302a7b7fee5": {
+                                        "keytype": "ed25519",
+                                        "scheme": "ed25519",
+                                        "keyval": {
+                                            "public": "7098f769f6ab8502b50f3b58686b8a042d5d3bb75d8b3a48a2fcbc15a0223501"
+                                        }
+                                    }
+                                },
+                                "roles": {
+                                    "snapshot": {
+                                        "keyids": [
+                                            "f7a6872f297634219a80141caa2ec9ae8802098b07b67963272603e36cc19fd8"
+                                        ],
+                                        "threshold": 1
+                                    },
+                                    "timestamp": {
+                                        "keyids": [
+                                            "f7a6872f297634219a80141caa2ec9ae8802098b07b67963272603e36cc19fd8"
+                                        ],
+                                        "threshold": 1
+                                    },
+                                    "targets": {
+                                        "keyids": [
+                                            "f7a6872f297634219a80141caa2ec9ae8802098b07b67963272603e36cc19fd8"
+                                        ],
+                                        "threshold": 1
+                                    },
+                                    "root": {
+                                        "keyids": [
+                                            "1cebe343e35f0213f6136758e6c3a8f8e1f9eeb7e47a07d5cb336462ed31dcb7",
+                                            "800dfb5a1982b82b7893e58035e19f414f553fc08cbb1130cfbae302a7b7fee5"
+                                        ],
+                                        "threshold": 1
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "MetadataSignPostPayload": {
+                "properties": {
+                    "role": {
+                        "type": "string",
+                        "title": "Role"
+                    },
+                    "signature": {
+                        "$ref": "#/components/schemas/MetadataSignature"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "role",
+                    "signature"
+                ],
+                "title": "MetadataSignPostPayload",
+                "example": {
+                    "role": "root",
+                    "signature": {
+                        "keyid": "800dfb5a1982b82b7893e58035e19f414f553fc08cbb1130cfbae302a7b7fee5",
+                        "sig": "1e60e79c909affba4f8051c7b86c861048450b4b32f1b9c106c50203a88877650a897b0c188af0ac0a530f1bccdafbdc2f92d0ee851864a6f24ddea031ef6b02"
+                    }
+                }
+            },
+            "MetadataSignature": {
+                "properties": {
+                    "keyid": {
+                        "type": "string",
+                        "title": "Keyid"
+                    },
+                    "sig": {
+                        "type": "string",
+                        "title": "Sig"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "keyid",
+                    "sig"
+                ],
+                "title": "MetadataSignature"
             },
             "PayloadTargetsHashes": {
                 "properties": {
@@ -1738,6 +1936,23 @@
                 ],
                 "title": "ValidationError"
             },
+            "repository_service_tuf_api__bootstrap__GetData": {
+                "properties": {
+                    "bootstrap": {
+                        "type": "boolean",
+                        "title": "Bootstrap"
+                    },
+                    "state": {
+                        "type": "string",
+                        "title": "State"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "bootstrap"
+                ],
+                "title": "GetData"
+            },
             "repository_service_tuf_api__bootstrap__PostData": {
                 "properties": {
                     "task_id": {
@@ -1825,6 +2040,22 @@
                     "expiration"
                 ],
                 "title": "Settings"
+            },
+            "repository_service_tuf_api__metadata__GetData": {
+                "properties": {
+                    "metadata": {
+                        "additionalProperties": {
+                            "$ref": "#/components/schemas/TUFMetadata"
+                        },
+                        "type": "object",
+                        "title": "Metadata"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "metadata"
+                ],
+                "title": "GetData"
             },
             "repository_service_tuf_api__metadata__PostData": {
                 "properties": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -233,8 +233,8 @@
                     "v1",
                     "v1"
                 ],
-                "summary": "Get the role metadata signing data. Scope: write:metadata",
-                "description": "Get signing the role metadata signging status and current metadata.",
+                "summary": "Get all metadata roles pending signatures. Scope: read:metadata",
+                "description": "Get all metadata roles that need more signatures before they can be used.",
                 "operationId": "get_sign_api_v1_metadata_sign_get",
                 "responses": {
                     "200": {
@@ -254,7 +254,7 @@
                 "security": [
                     {
                         "OAuth2PasswordBearer": [
-                            "write:metadata"
+                            "read:metadata"
                         ]
                     }
                 ]
@@ -264,8 +264,8 @@
                     "v1",
                     "v1"
                 ],
-                "summary": "Get the role metadata signing data. Scope: write:metadata",
-                "description": "Get signing the role metadata signging status and current metadata.",
+                "summary": "Add a signature for a metadata role. Scope: write:metadata",
+                "description": "Add a signature for a metadata role.",
                 "operationId": "post_sign_api_v1_metadata_sign_post",
                 "requestBody": {
                     "content": {
@@ -871,7 +871,7 @@
                     "scope": {
                         "type": "string",
                         "title": "Scope",
-                        "description": "Add scopes separeted by space. Available scopes: `read:bootstrap`, `read:settings`, `read:tasks`, `read:token`, `write:bootstrap`, `write:settings`, `write:metadata`, `write:targets`, `write:token`, `delete:targets`"
+                        "description": "Add scopes separeted by space. Available scopes: `read:bootstrap`, `read:settings`, `read:tasks`, `read:token`, `write:bootstrap`, `write:settings`, `write:metadata`, `read:metadata`, `write:targets`, `write:token`, `delete:targets`"
                     },
                     "expires": {
                         "type": "integer",
@@ -892,7 +892,7 @@
             "BootstrapGetResponse": {
                 "properties": {
                     "data": {
-                        "$ref": "#/components/schemas/repository_service_tuf_api__bootstrap__GetData"
+                        "$ref": "#/components/schemas/GetData"
                     },
                     "message": {
                         "type": "string",
@@ -1075,6 +1075,23 @@
                     ]
                 }
             },
+            "GetData": {
+                "properties": {
+                    "bootstrap": {
+                        "type": "boolean",
+                        "title": "Bootstrap"
+                    },
+                    "state": {
+                        "type": "string",
+                        "title": "State"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "bootstrap"
+                ],
+                "title": "GetData"
+            },
             "GetTokenResponse": {
                 "properties": {
                     "data": {
@@ -1101,6 +1118,7 @@
                             "write:bootstrap",
                             "write:settings",
                             "write:metadata",
+                            "read:metadata",
                             "write:targets",
                             "write:token",
                             "delete:targets"
@@ -1255,7 +1273,7 @@
             "MetadataSignGetResponse": {
                 "properties": {
                     "data": {
-                        "$ref": "#/components/schemas/repository_service_tuf_api__metadata__GetData"
+                        "$ref": "#/components/schemas/SigningData"
                     },
                     "message": {
                         "type": "string",
@@ -1273,50 +1291,56 @@
                             "signatures": [
                                 {
                                     "keyid": "1cebe343e35f0213f6136758e6c3a8f8e1f9eeb7e47a07d5cb336462ed31dcb7",
-                                    "sig": "b3c81b6579442b8672ff460ac36cdb51064109fcfa93f0e72dabbf338f7d0c24e1a91d3696d72d81f60e94b2782ab1bf41e6b8f3e535538216f4379bf30a4302"
-                                },
-                                {
-                                    "keyid": "800dfb5a1982b82b7893e58035e19f414f553fc08cbb1130cfbae302a7b7fee5",
-                                    "sig": "fdfbb1877da404504e8b9c111d87680df5291094dafa01f66bfe6031e470d7c63cc477c1e79210a89e27734758e54fb54adc529918b1211d9dd9971c8bb26c0a"
+                                    "sig": "9d00b77ca94da3ec38600bc64b612767efff792119207d51f7be62222d63498c86373e83662f13dbf476840716eab32ef37e90b1dac37eba1c2cd1755487f306"
                                 }
                             ],
                             "signed": {
                                 "_type": "root",
                                 "version": 1,
                                 "spec_version": "1.0.30",
-                                "expires": "2024-02-17T10:55:28Z",
+                                "expires": "2024-07-12T09:03:48Z",
                                 "consistent_snapshot": true,
                                 "keys": {
-                                    "f7a6872f297634219a80141caa2ec9ae8802098b07b67963272603e36cc19fd8": {
-                                        "keytype": "ed25519",
-                                        "scheme": "ed25519",
-                                        "keyval": {
-                                            "public": "9fe7ddccb75b977a041424a1fdc142e01be4abab918dc4c611fbfe4a3360a9a8"
-                                        }
-                                    },
                                     "1cebe343e35f0213f6136758e6c3a8f8e1f9eeb7e47a07d5cb336462ed31dcb7": {
                                         "keytype": "ed25519",
                                         "scheme": "ed25519",
                                         "keyval": {
                                             "public": "ad1709b3cb419b99c5cd7427d6411522e5a93aec6767453e91af921a73d22a3c"
-                                        }
+                                        },
+                                        "name": "jj"
                                     },
                                     "800dfb5a1982b82b7893e58035e19f414f553fc08cbb1130cfbae302a7b7fee5": {
                                         "keytype": "ed25519",
                                         "scheme": "ed25519",
                                         "keyval": {
                                             "public": "7098f769f6ab8502b50f3b58686b8a042d5d3bb75d8b3a48a2fcbc15a0223501"
-                                        }
+                                        },
+                                        "name": "jh"
+                                    },
+                                    "f7a6872f297634219a80141caa2ec9ae8802098b07b67963272603e36cc19fd8": {
+                                        "keytype": "ed25519",
+                                        "scheme": "ed25519",
+                                        "keyval": {
+                                            "public": "9fe7ddccb75b977a041424a1fdc142e01be4abab918dc4c611fbfe4a3360a9a8"
+                                        },
+                                        "name": "o"
                                     }
                                 },
                                 "roles": {
-                                    "snapshot": {
+                                    "root": {
+                                        "keyids": [
+                                            "1cebe343e35f0213f6136758e6c3a8f8e1f9eeb7e47a07d5cb336462ed31dcb7",
+                                            "800dfb5a1982b82b7893e58035e19f414f553fc08cbb1130cfbae302a7b7fee5"
+                                        ],
+                                        "threshold": 2
+                                    },
+                                    "timestamp": {
                                         "keyids": [
                                             "f7a6872f297634219a80141caa2ec9ae8802098b07b67963272603e36cc19fd8"
                                         ],
                                         "threshold": 1
                                     },
-                                    "timestamp": {
+                                    "snapshot": {
                                         "keyids": [
                                             "f7a6872f297634219a80141caa2ec9ae8802098b07b67963272603e36cc19fd8"
                                         ],
@@ -1325,13 +1349,6 @@
                                     "targets": {
                                         "keyids": [
                                             "f7a6872f297634219a80141caa2ec9ae8802098b07b67963272603e36cc19fd8"
-                                        ],
-                                        "threshold": 1
-                                    },
-                                    "root": {
-                                        "keyids": [
-                                            "1cebe343e35f0213f6136758e6c3a8f8e1f9eeb7e47a07d5cb336462ed31dcb7",
-                                            "800dfb5a1982b82b7893e58035e19f414f553fc08cbb1130cfbae302a7b7fee5"
                                         ],
                                         "threshold": 1
                                     }
@@ -1507,6 +1524,22 @@
                     "targets_online_key"
                 ],
                 "title": "ServiceSettings"
+            },
+            "SigningData": {
+                "properties": {
+                    "metadata": {
+                        "additionalProperties": {
+                            "$ref": "#/components/schemas/TUFMetadata"
+                        },
+                        "type": "object",
+                        "title": "Metadata"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "metadata"
+                ],
+                "title": "SigningData"
             },
             "TUFKeys": {
                 "properties": {
@@ -1936,23 +1969,6 @@
                 ],
                 "title": "ValidationError"
             },
-            "repository_service_tuf_api__bootstrap__GetData": {
-                "properties": {
-                    "bootstrap": {
-                        "type": "boolean",
-                        "title": "Bootstrap"
-                    },
-                    "state": {
-                        "type": "string",
-                        "title": "State"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "bootstrap"
-                ],
-                "title": "GetData"
-            },
             "repository_service_tuf_api__bootstrap__PostData": {
                 "properties": {
                     "task_id": {
@@ -2041,22 +2057,6 @@
                 ],
                 "title": "Settings"
             },
-            "repository_service_tuf_api__metadata__GetData": {
-                "properties": {
-                    "metadata": {
-                        "additionalProperties": {
-                            "$ref": "#/components/schemas/TUFMetadata"
-                        },
-                        "type": "object",
-                        "title": "Metadata"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "metadata"
-                ],
-                "title": "GetData"
-            },
             "repository_service_tuf_api__metadata__PostData": {
                 "properties": {
                     "task_id": {
@@ -2132,6 +2132,7 @@
                             "read:settings": "Read (GET) settings",
                             "read:tasks": "Read (GET) tasks",
                             "read:token": "Read (GET) tokens",
+                            "read:metadata": "Read (GET) metadata",
                             "write:targets": "Write (POST) targets",
                             "write:token": "Write (POST) token",
                             "write:bootstrap": "Write (POST) bootstrap",

--- a/repository_service_tuf_api/__init__.py
+++ b/repository_service_tuf_api/__init__.py
@@ -45,6 +45,7 @@ class SCOPES_NAMES(Enum):
     write_bootstrap = "write:bootstrap"
     write_settings = "write:settings"
     write_metadata = "write:metadata"
+    read_metadata = "read:metadata"
     write_targets = "write:targets"
     write_token = "write:token"  # nosec bandit: not hard coded password
     delete_targets = "delete:targets"
@@ -55,6 +56,7 @@ SCOPES = {
     SCOPES_NAMES.read_settings.value: "Read (GET) settings",
     SCOPES_NAMES.read_tasks.value: "Read (GET) tasks",
     SCOPES_NAMES.read_token.value: "Read (GET) tokens",
+    SCOPES_NAMES.read_metadata.value: "Read (GET) metadata",
     SCOPES_NAMES.write_targets.value: "Write (POST) targets",
     SCOPES_NAMES.write_token.value: "Write (POST) token",
     SCOPES_NAMES.write_bootstrap.value: "Write (POST) bootstrap",

--- a/repository_service_tuf_api/api/metadata.py
+++ b/repository_service_tuf_api/api/metadata.py
@@ -36,11 +36,11 @@ def post(
 @router.get(
     "/sign",
     summary=(
-        "Get the role metadata signing data. Scope: "
+        "Get all metadata roles pending signatures. Scope: "
         f"{SCOPES_NAMES.write_metadata.value}"
     ),
     description=(
-        "Get signing the role metadata signging status and current metadata."
+        "Get all metadata roles that need more signatures before they can be used."
     ),
     response_model=metadata.MetadataSignGetResponse,
     response_model_exclude_none=True,
@@ -55,11 +55,11 @@ def get_sign(
 @router.post(
     "/sign",
     summary=(
-        "Get the role metadata signing data. Scope: "
+        "Add a signate for a metadata role"
         f"{SCOPES_NAMES.write_metadata.value}"
     ),
     description=(
-        "Get signing the role metadata signging status and current metadata."
+        "Add a signature for a metadata role."
     ),
     response_model=metadata.MetadataPostResponse,
     response_model_exclude_none=True,

--- a/repository_service_tuf_api/api/metadata.py
+++ b/repository_service_tuf_api/api/metadata.py
@@ -40,7 +40,8 @@ def post(
         f"{SCOPES_NAMES.write_metadata.value}"
     ),
     description=(
-        "Get all metadata roles that need more signatures before they can be used."
+        "Get all metadata roles that need more signatures before they can be "
+        "used."
     ),
     response_model=metadata.MetadataSignGetResponse,
     response_model_exclude_none=True,
@@ -55,12 +56,10 @@ def get_sign(
 @router.post(
     "/sign",
     summary=(
-        "Add a signate for a metadata role"
+        "Add a signature for a metadata role. Scope: "
         f"{SCOPES_NAMES.write_metadata.value}"
     ),
-    description=(
-        "Add a signature for a metadata role."
-    ),
+    description=("Add a signature for a metadata role."),
     response_model=metadata.MetadataPostResponse,
     response_model_exclude_none=True,
     status_code=status.HTTP_202_ACCEPTED,

--- a/repository_service_tuf_api/api/metadata.py
+++ b/repository_service_tuf_api/api/metadata.py
@@ -37,7 +37,7 @@ def post(
     "/sign",
     summary=(
         "Get all metadata roles pending signatures. Scope: "
-        f"{SCOPES_NAMES.write_metadata.value}"
+        f"{SCOPES_NAMES.read_metadata.value}"
     ),
     description=(
         "Get all metadata roles that need more signatures before they can be "
@@ -48,7 +48,7 @@ def post(
     status_code=status.HTTP_200_OK,
 )
 def get_sign(
-    _user=Security(auth, scopes=[SCOPES_NAMES.write_metadata.value]),
+    _user=Security(auth, scopes=[SCOPES_NAMES.read_metadata.value]),
 ):
     return metadata.get_metadata_sign()
 

--- a/repository_service_tuf_api/api/metadata.py
+++ b/repository_service_tuf_api/api/metadata.py
@@ -31,3 +31,42 @@ def post(
     _user=Security(auth, scopes=[SCOPES_NAMES.write_metadata.value]),
 ):
     return metadata.post_metadata(payload)
+
+
+@router.get(
+    "/sign",
+    summary=(
+        "Get the role metadata signing data. Scope: "
+        f"{SCOPES_NAMES.write_metadata.value}"
+    ),
+    description=(
+        "Get signing the role metadata signging status and current metadata."
+    ),
+    response_model=metadata.MetadataSignGetResponse,
+    response_model_exclude_none=True,
+    status_code=status.HTTP_200_OK,
+)
+def get_sign(
+    _user=Security(auth, scopes=[SCOPES_NAMES.write_metadata.value]),
+):
+    return metadata.get_metadata_sign()
+
+
+@router.post(
+    "/sign",
+    summary=(
+        "Get the role metadata signing data. Scope: "
+        f"{SCOPES_NAMES.write_metadata.value}"
+    ),
+    description=(
+        "Get signing the role metadata signging status and current metadata."
+    ),
+    response_model=metadata.MetadataPostResponse,
+    response_model_exclude_none=True,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+def post_sign(
+    payload: metadata.MetadataSignPostPayload,
+    _user=Security(auth, scopes=[SCOPES_NAMES.write_metadata.value]),
+):
+    return metadata.post_metadata_sign(payload)

--- a/repository_service_tuf_api/metadata.py
+++ b/repository_service_tuf_api/metadata.py
@@ -78,7 +78,7 @@ def post_metadata(payload: MetadataPostPayload) -> MetadataPostResponse:
     )
 
 
-class GetData(BaseModel):
+class SigningData(BaseModel):
     metadata: Dict[Roles, TUFMetadata]
 
 
@@ -104,18 +104,18 @@ def get_metadata_sign() -> MetadataSignGetResponse:
             detail={
                 "message": "No signing available",
                 "error": (
-                    f"It requires bootstrap started. State: {bs_state.state}"
+                    f"Requires bootstrap started. State: {bs_state.state}"
                 ),
             },
         )
 
     settings_repository.reload()
-    available_signing = list(
+    pending_signing = list(
         filter(lambda var: "SIGNING" in var, dir(settings_repository))
     )
 
     metadata_response: Dict[str, TUFMetadata] = {}
-    for singing in available_signing:
+    for role in pending_signing:
         signing_md = settings_repository.get(singing)
         if signing_md is not None:
             metadata_response[
@@ -124,7 +124,7 @@ def get_metadata_sign() -> MetadataSignGetResponse:
 
     return MetadataSignGetResponse(
         data={"metadata": metadata_response},
-        message="Available signing Metadata(s)",
+        message="Metadata role(s) pending signing",
     )
 
 
@@ -137,7 +137,7 @@ class MetadataSignPostResponse(BaseModel):
             "data": {
                 "task_id": "7a634b556f784ae88785d36425f9a218",
             },
-            "message": "Metadata Update accepted.",
+            "message": "Metadata sign accepted.",
         }
 
         schema_extra = {"example": example}
@@ -181,7 +181,7 @@ def post_metadata_sign(
             detail={
                 "message": "No signing pending.",
                 "error": (
-                    "It requires bootstrap in signing state. "
+                    "Requires bootstrap in signing state. "
                     f"State: {bs_state.state}"
                 ),
             },

--- a/repository_service_tuf_api/metadata.py
+++ b/repository_service_tuf_api/metadata.py
@@ -56,7 +56,7 @@ def post_metadata(payload: MetadataPostPayload) -> MetadataPostResponse:
             detail={
                 "message": "Task not accepted.",
                 "error": (
-                    f"It requires bootstrap finished. State: {bs_state.state}"
+                    f"Requires bootstrap finished. State: {bs_state.state}"
                 ),
             },
         )
@@ -83,7 +83,7 @@ class SigningData(BaseModel):
 
 
 class MetadataSignGetResponse(BaseModel):
-    data: Optional[GetData]
+    data: Optional[SigningData]
     message: str
 
     class Config:
@@ -116,10 +116,10 @@ def get_metadata_sign() -> MetadataSignGetResponse:
 
     metadata_response: Dict[str, TUFMetadata] = {}
     for role in pending_signing:
-        signing_md = settings_repository.get(singing)
+        signing_md = settings_repository.get(role)
         if signing_md is not None:
             metadata_response[
-                singing.split("_")[0].lower()
+                role.split("_")[0].lower()
             ] = signing_md.to_dict()
 
     return MetadataSignGetResponse(

--- a/repository_service_tuf_api/metadata.py
+++ b/repository_service_tuf_api/metadata.py
@@ -12,6 +12,7 @@ from repository_service_tuf_api import (
     bootstrap_state,
     get_task_id,
     repository_metadata,
+    settings_repository,
 )
 from repository_service_tuf_api.common_models import Roles, TUFMetadata
 
@@ -41,7 +42,7 @@ class MetadataPostResponse(BaseModel):
             "data": {
                 "task_id": "7a634b556f784ae88785d36425f9a218",
             },
-            "message": "Bootstrap accepted.",
+            "message": "Metadata Update accepted.",
         }
 
         schema_extra = {"example": example}
@@ -74,4 +75,130 @@ def post_metadata(payload: MetadataPostPayload) -> MetadataPostResponse:
 
     return MetadataPostResponse(
         data={"task_id": task_id}, message="Metadata update accepted."
+    )
+
+
+class GetData(BaseModel):
+    metadata: Dict[Roles, TUFMetadata]
+
+
+class MetadataSignGetResponse(BaseModel):
+    data: Optional[GetData]
+    message: str
+
+    class Config:
+        with open("tests/data_examples/bootstrap/payload.json") as f:
+            content = f.read()
+        example = json.loads(content)
+        schema_extra = {
+            "example": {"metadata": {"root": example["metadata"]["root"]}}
+        }
+
+
+def get_metadata_sign() -> MetadataSignGetResponse:
+    bs_state = bootstrap_state()
+    # Adds support only when bootstrap is signing state
+    if bs_state.bootstrap is False and bs_state.state != "signing":
+        raise HTTPException(
+            status.HTTP_200_OK,
+            detail={
+                "message": "No signing available",
+                "error": (
+                    f"It requires bootstrap started. State: {bs_state.state}"
+                ),
+            },
+        )
+
+    settings_repository.reload()
+    available_signing = list(
+        filter(lambda var: "SIGNING" in var, dir(settings_repository))
+    )
+
+    metadata_response: Dict[str, TUFMetadata] = {}
+    for singing in available_signing:
+        signing_md = settings_repository.get(singing)
+        if signing_md is not None:
+            metadata_response[
+                singing.split("_")[0].lower()
+            ] = signing_md.to_dict()
+
+    return MetadataSignGetResponse(
+        data={"metadata": metadata_response},
+        message="Available signing Metadata(s)",
+    )
+
+
+class MetadataSignPostResponse(BaseModel):
+    data: Optional[PostData]
+    message: str
+
+    class Config:
+        example = {
+            "data": {
+                "task_id": "7a634b556f784ae88785d36425f9a218",
+            },
+            "message": "Metadata Update accepted.",
+        }
+
+        schema_extra = {"example": example}
+
+
+class MetadataSignature(BaseModel):
+    keyid: str
+    sig: str
+
+
+class MetadataSignPostPayload(BaseModel):
+    role: str
+    signature: MetadataSignature
+
+    class Config:
+        schema_extra = {
+            "example": {
+                "role": "root",
+                "signature": {
+                    "keyid": (
+                        "800dfb5a1982b82b7893e58035e19f414f553fc08cbb1130cfbae"
+                        "302a7b7fee5"
+                    ),
+                    "sig": (
+                        "1e60e79c909affba4f8051c7b86c861048450b4b32f1b9c106c50"
+                        "203a88877650a897b0c188af0ac0a530f1bccdafbdc2f92d0ee85"
+                        "1864a6f24ddea031ef6b02"
+                    ),
+                },
+            }
+        }
+
+
+def post_metadata_sign(
+    payload: MetadataSignPostPayload,
+) -> MetadataSignPostResponse:
+    bs_state = bootstrap_state()
+    if bs_state.bootstrap is False and bs_state.state != "signing":
+        raise HTTPException(
+            status.HTTP_200_OK,
+            detail={
+                "message": "No signing pending.",
+                "error": (
+                    "It requires bootstrap in signing state. "
+                    f"State: {bs_state.state}"
+                ),
+            },
+        )
+
+    task_id = get_task_id()
+
+    repository_metadata.apply_async(
+        kwargs={
+            "action": "sign_metadata",
+            "payload": payload.dict(by_alias=True, exclude_none=True),
+        },
+        task_id=task_id,
+        queue="metadata_repository",
+        acks_late=True,
+    )
+
+    return MetadataPostResponse(
+        data={"task_id": task_id}, message="Metadata sign accepted."
     )

--- a/repository_service_tuf_api/metadata.py
+++ b/repository_service_tuf_api/metadata.py
@@ -87,7 +87,7 @@ class MetadataSignGetResponse(BaseModel):
     message: str
 
     class Config:
-        with open("tests/data_examples/bootstrap/payload.json") as f:
+        with open("tests/data_examples/bootstrap/das-payload.json") as f:
             content = f.read()
         example = json.loads(content)
         schema_extra = {

--- a/tests/data_examples/bootstrap/das-payload.json
+++ b/tests/data_examples/bootstrap/das-payload.json
@@ -1,0 +1,86 @@
+{
+  "settings": {
+    "expiration": {
+      "root": 365,
+      "targets": 365,
+      "snapshot": 1,
+      "timestamp": 1,
+      "bins": 1
+    },
+    "services": {
+      "number_of_delegated_bins": 4,
+      "targets_base_url": "f/",
+      "targets_online_key": true
+    }
+  },
+  "metadata": {
+    "root": {
+      "signatures": [
+        {
+          "keyid": "1cebe343e35f0213f6136758e6c3a8f8e1f9eeb7e47a07d5cb336462ed31dcb7",
+          "sig": "9d00b77ca94da3ec38600bc64b612767efff792119207d51f7be62222d63498c86373e83662f13dbf476840716eab32ef37e90b1dac37eba1c2cd1755487f306"
+        }
+      ],
+      "signed": {
+        "_type": "root",
+        "version": 1,
+        "spec_version": "1.0.30",
+        "expires": "2024-07-12T09:03:48Z",
+        "consistent_snapshot": true,
+        "keys": {
+          "1cebe343e35f0213f6136758e6c3a8f8e1f9eeb7e47a07d5cb336462ed31dcb7": {
+            "keytype": "ed25519",
+            "scheme": "ed25519",
+            "keyval": {
+              "public": "ad1709b3cb419b99c5cd7427d6411522e5a93aec6767453e91af921a73d22a3c"
+            },
+            "name": "jj"
+          },
+          "800dfb5a1982b82b7893e58035e19f414f553fc08cbb1130cfbae302a7b7fee5": {
+            "keytype": "ed25519",
+            "scheme": "ed25519",
+            "keyval": {
+              "public": "7098f769f6ab8502b50f3b58686b8a042d5d3bb75d8b3a48a2fcbc15a0223501"
+            },
+            "name": "jh"
+          },
+          "f7a6872f297634219a80141caa2ec9ae8802098b07b67963272603e36cc19fd8": {
+            "keytype": "ed25519",
+            "scheme": "ed25519",
+            "keyval": {
+              "public": "9fe7ddccb75b977a041424a1fdc142e01be4abab918dc4c611fbfe4a3360a9a8"
+            },
+            "name": "o"
+          }
+        },
+        "roles": {
+          "root": {
+            "keyids": [
+              "1cebe343e35f0213f6136758e6c3a8f8e1f9eeb7e47a07d5cb336462ed31dcb7",
+              "800dfb5a1982b82b7893e58035e19f414f553fc08cbb1130cfbae302a7b7fee5"
+            ],
+            "threshold": 2
+          },
+          "timestamp": {
+            "keyids": [
+              "f7a6872f297634219a80141caa2ec9ae8802098b07b67963272603e36cc19fd8"
+            ],
+            "threshold": 1
+          },
+          "snapshot": {
+            "keyids": [
+              "f7a6872f297634219a80141caa2ec9ae8802098b07b67963272603e36cc19fd8"
+            ],
+            "threshold": 1
+          },
+          "targets": {
+            "keyids": [
+              "f7a6872f297634219a80141caa2ec9ae8802098b07b67963272603e36cc19fd8"
+            ],
+            "threshold": 1
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/unit/api/test_metadata.py
+++ b/tests/unit/api/test_metadata.py
@@ -72,7 +72,7 @@ class TestPostMetadata:
         assert response.json() == {
             "detail": {
                 "message": "Task not accepted.",
-                "error": "It requires bootstrap finished. State: None",
+                "error": "Requires bootstrap finished. State: None",
             }
         }
         assert mocked_bootstrap_state.calls == [pretend.call()]
@@ -102,7 +102,7 @@ class TestPostMetadata:
         assert response.json() == {
             "detail": {
                 "message": "Task not accepted.",
-                "error": "It requires bootstrap finished. State: signing",
+                "error": "Requires bootstrap finished. State: signing",
             }
         }
         assert mocked_bootstrap_state.calls == [pretend.call()]
@@ -218,7 +218,7 @@ class TestGetMetadataSign:
         assert response.status_code == status.HTTP_200_OK, response.text
         assert response.json() == {
             "data": {"metadata": {"root": metadata_data["metadata"]["root"]}},
-            "message": "Available signing Metadata(s)",
+            "message": "Metadata role(s) pending signing",
         }
         assert mocked_bootstrap_state.calls == [pretend.call()]
         assert mocked_settings_repository.reload.calls == [pretend.call()]
@@ -245,7 +245,7 @@ class TestGetMetadataSign:
         assert response.json() == {
             "detail": {
                 "message": "No signing available",
-                "error": "It requires bootstrap started. State: None",
+                "error": "Requires bootstrap started. State: None",
             }
         }
         assert mocked_bootstrap_state.calls == [pretend.call()]
@@ -268,7 +268,7 @@ class TestGetMetadataSign:
         assert response.json() == {
             "detail": {
                 "message": "No signing available",
-                "error": "It requires bootstrap started. State: pre",
+                "error": "Requires bootstrap started. State: pre",
             }
         }
         assert mocked_bootstrap_state.calls == [pretend.call()]
@@ -339,7 +339,7 @@ class TestPostMetadataSign:
         assert response.json() == {
             "detail": {
                 "message": "No signing pending.",
-                "error": "It requires bootstrap in signing state. State: None",
+                "error": "Requires bootstrap in signing state. State: None",
             }
         }
         assert mocked_bootstrap_state.calls == [pretend.call()]
@@ -364,7 +364,7 @@ class TestPostMetadataSign:
             "detail": {
                 "message": "No signing pending.",
                 "error": (
-                    "It requires bootstrap in signing state. State: finished"
+                    "Requires bootstrap in signing state. State: finished"
                 ),
             }
         }

--- a/tests/unit/api/test_metadata.py
+++ b/tests/unit/api/test_metadata.py
@@ -183,3 +183,189 @@ class TestPostMetadata:
             "type": "value_error.const",
             "ctx": {"given": "timestamp", "permitted": ["root"]},
         } in response.json()["detail"]
+
+
+class TestGetMetadataSign:
+    def test_get_metadata_sign(self, test_client, token_headers, monkeypatch):
+        url = "/api/v1/metadata/sign/"
+
+        mocked_bootstrap_state = pretend.call_recorder(
+            lambda *a: pretend.stub(bootstrap=True, state="signing")
+        )
+        monkeypatch.setattr(
+            "repository_service_tuf_api.metadata.bootstrap_state",
+            mocked_bootstrap_state,
+        )
+        with open("tests/data_examples/bootstrap/payload.json") as f:
+            md_content = f.read()
+        metadata_data = json.loads(md_content)
+        fake_metadata = pretend.stub(
+            to_dict=pretend.call_recorder(
+                lambda: metadata_data["metadata"]["root"]
+            )
+        )
+        mocked_settings_repository = pretend.stub(
+            reload=pretend.call_recorder(lambda: None),
+            get=pretend.call_recorder(lambda *a: fake_metadata),
+            ROOT_SIGNING=fake_metadata,
+        )
+        monkeypatch.setattr(
+            "repository_service_tuf_api.metadata.settings_repository",
+            mocked_settings_repository,
+        )
+
+        response = test_client.get(url, headers=token_headers)
+        assert response.status_code == status.HTTP_200_OK, response.text
+        assert response.json() == {
+            "data": {"metadata": {"root": metadata_data["metadata"]["root"]}},
+            "message": "Available signing Metadata(s)",
+        }
+        assert mocked_bootstrap_state.calls == [pretend.call()]
+        assert mocked_settings_repository.reload.calls == [pretend.call()]
+        assert mocked_settings_repository.get.calls == [
+            pretend.call("ROOT_SIGNING")
+        ]
+        assert fake_metadata.to_dict.calls == [pretend.call()]
+
+    def test_get_metadata_sign_no_bootstrap(
+        self, test_client, token_headers, monkeypatch
+    ):
+        url = "/api/v1/metadata/sign/"
+
+        mocked_bootstrap_state = pretend.call_recorder(
+            lambda *a: pretend.stub(bootstrap=False, state=None)
+        )
+        monkeypatch.setattr(
+            "repository_service_tuf_api.metadata.bootstrap_state",
+            mocked_bootstrap_state,
+        )
+        response = test_client.get(url, headers=token_headers)
+
+        assert response.status_code == status.HTTP_200_OK, response.text
+        assert response.json() == {
+            "detail": {
+                "message": "No signing available",
+                "error": "It requires bootstrap started. State: None",
+            }
+        }
+        assert mocked_bootstrap_state.calls == [pretend.call()]
+
+    def test_get_metadata_sign_bootstrap_pre(
+        self, test_client, token_headers, monkeypatch
+    ):
+        url = "/api/v1/metadata/sign/"
+
+        mocked_bootstrap_state = pretend.call_recorder(
+            lambda *a: pretend.stub(bootstrap=False, state="pre")
+        )
+        monkeypatch.setattr(
+            "repository_service_tuf_api.metadata.bootstrap_state",
+            mocked_bootstrap_state,
+        )
+        response = test_client.get(url, headers=token_headers)
+
+        assert response.status_code == status.HTTP_200_OK, response.text
+        assert response.json() == {
+            "detail": {
+                "message": "No signing available",
+                "error": "It requires bootstrap started. State: pre",
+            }
+        }
+        assert mocked_bootstrap_state.calls == [pretend.call()]
+
+
+class TestPostMetadataSign:
+    def test_post_metadata_sign(self, test_client, token_headers, monkeypatch):
+        url = "/api/v1/metadata/sign/"
+
+        mocked_bootstrap_state = pretend.call_recorder(
+            lambda *a: pretend.stub(bootstrap=True, state="signing")
+        )
+        monkeypatch.setattr(
+            "repository_service_tuf_api.metadata.bootstrap_state",
+            mocked_bootstrap_state,
+        )
+        monkeypatch.setattr(
+            "repository_service_tuf_api.metadata.get_task_id",
+            lambda: "fake_id",
+        )
+        fake_repository_metadata = pretend.stub(
+            apply_async=pretend.call_recorder(lambda *a, **kw: None)
+        )
+        monkeypatch.setattr(
+            "repository_service_tuf_api.metadata.repository_metadata",
+            fake_repository_metadata,
+        )
+        payload = {"role": "root", "signature": {"keyid": "k1", "sig": "s1"}}
+
+        response = test_client.post(url, json=payload, headers=token_headers)
+        assert response.status_code == status.HTTP_202_ACCEPTED, response.text
+        assert response.json() == {
+            "data": {"task_id": "fake_id"},
+            "message": "Metadata sign accepted.",
+        }
+        assert mocked_bootstrap_state.calls == [pretend.call()]
+        assert fake_repository_metadata.apply_async.calls == [
+            pretend.call(
+                kwargs={
+                    "action": "sign_metadata",
+                    "payload": {
+                        "role": "root",
+                        "signature": {"keyid": "k1", "sig": "s1"},
+                    },
+                },
+                task_id="fake_id",
+                queue="metadata_repository",
+                acks_late=True,
+            )
+        ]
+
+    def test_post_metadata_no_bootstrap(
+        self, test_client, token_headers, monkeypatch
+    ):
+        url = "/api/v1/metadata/sign/"
+
+        mocked_bootstrap_state = pretend.call_recorder(
+            lambda *a: pretend.stub(bootstrap=False, state=None)
+        )
+        monkeypatch.setattr(
+            "repository_service_tuf_api.metadata.bootstrap_state",
+            mocked_bootstrap_state,
+        )
+        payload = {"role": "root", "signature": {"keyid": "k1", "sig": "s1"}}
+
+        response = test_client.post(url, json=payload, headers=token_headers)
+        assert response.status_code == status.HTTP_200_OK, response.text
+        assert response.json() == {
+            "detail": {
+                "message": "No signing pending.",
+                "error": "It requires bootstrap in signing state. State: None",
+            }
+        }
+        assert mocked_bootstrap_state.calls == [pretend.call()]
+
+    def test_post_metadata_bootstrap_finished(
+        self, test_client, token_headers, monkeypatch
+    ):
+        url = "/api/v1/metadata/sign/"
+
+        mocked_bootstrap_state = pretend.call_recorder(
+            lambda *a: pretend.stub(bootstrap=False, state="finished")
+        )
+        monkeypatch.setattr(
+            "repository_service_tuf_api.metadata.bootstrap_state",
+            mocked_bootstrap_state,
+        )
+        payload = {"role": "root", "signature": {"keyid": "k1", "sig": "s1"}}
+
+        response = test_client.post(url, json=payload, headers=token_headers)
+        assert response.status_code == status.HTTP_200_OK, response.text
+        assert response.json() == {
+            "detail": {
+                "message": "No signing pending.",
+                "error": (
+                    "It requires bootstrap in signing state. State: finished"
+                ),
+            }
+        }
+        assert mocked_bootstrap_state.calls == [pretend.call()]

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -28,6 +28,7 @@ def token_headers(test_client):
             "write:targets "
             "write:bootstrap "
             "write:metadata "
+            "read:metadata "
             "read:bootstrap "
             "write:settings "
             "read:settings "


### PR DESCRIPTION
# Description

It implements the base structure endpoints for the distributed async signing for the RSTUF.

The implementation also adds support to the distributed async sign for the bootstrap. The user can initiate the bootstrap ceremony process with the Root metadata not fully signed, and the other root ey owners can start the signing process.

It requires
 - https://github.com/repository-service-tuf/repository-service-tuf-worker/issues/300

Closes #355

# Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)


# Additional requirements
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


# Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.rst).

- [x] I agree to follow this project's Code of Conduct