### PR TITLE
fix: scopes in the API body validation for token

### DIFF
--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1907,7 +1907,11 @@
                                 "read:settings",
                                 "read:tasks",
                                 "read:token",
+                                "read:metadata",
                                 "write:targets",
+                                "write:bootstrap",
+                                "write:settings",
+                                "write:metadata",
                                 "delete:targets"
                             ]
                         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1909,7 +1909,6 @@
                                 "read:token",
                                 "read:metadata",
                                 "write:targets",
-                                "write:bootstrap",
                                 "write:settings",
                                 "write:metadata",
                                 "delete:targets"

--- a/repository_service_tuf_api/token.py
+++ b/repository_service_tuf_api/token.py
@@ -91,7 +91,6 @@ class TokenRequestPayload(BaseModel):
             SCOPES_NAMES.read_token.value,
             SCOPES_NAMES.read_metadata.value,
             SCOPES_NAMES.write_targets.value,
-            SCOPES_NAMES.write_bootstrap.value,
             SCOPES_NAMES.write_settings.value,
             SCOPES_NAMES.write_metadata.value,
             SCOPES_NAMES.delete_targets.value,

--- a/repository_service_tuf_api/token.py
+++ b/repository_service_tuf_api/token.py
@@ -89,7 +89,11 @@ class TokenRequestPayload(BaseModel):
             SCOPES_NAMES.read_settings.value,
             SCOPES_NAMES.read_tasks.value,
             SCOPES_NAMES.read_token.value,
+            SCOPES_NAMES.read_metadata.value,
             SCOPES_NAMES.write_targets.value,
+            SCOPES_NAMES.write_bootstrap.value,
+            SCOPES_NAMES.write_settings.value,
+            SCOPES_NAMES.write_metadata.value,
             SCOPES_NAMES.delete_targets.value,
         ]
     ] = Field(min_items=1)


### PR DESCRIPTION
# Description

Fix the missing scopes in the API body validation for issuing tokens.

<!--- What is the PR about? -->

This PR is a quick fixing an existent bug when trying to issue a token with certain scopes.
The scopes are unlisted on the API validation.
This commit adds this missing scopes.

#### Note:
It is a quick fix. This is a manual update for the scope list.
The idea is to [generate a dynamic list of allowed scopes when issuing tokens](https://github.com/repository-service-tuf/repository-service-tuf-api/issues/409).
If someone has a quick fix using dynamic, feel free to replace this PR.

<!--- Please reference the issue(s) this PR fixes. -->
Fixes #408 


# Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)


# Additional requirements
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


# Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.rst).

- [x] I agree to follow this project's Code of Conduct