### PR TITLE
Allow more hashing algorithms for TargetFiles

### DIFF
--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1400,19 +1400,6 @@
                 ],
                 "title": "MetadataSignature"
             },
-            "PayloadTargetsHashes": {
-                "properties": {
-                    "blake2b-256": {
-                        "type": "string",
-                        "title": "Blake2B-256"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "blake2b-256"
-                ],
-                "title": "PayloadTargetsHashes"
-            },
             "PostTokenResponse": {
                 "properties": {
                     "access_token": {
@@ -1834,7 +1821,12 @@
                         "title": "Length"
                     },
                     "hashes": {
-                        "$ref": "#/components/schemas/PayloadTargetsHashes"
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "type": "object",
+                        "title": "Hashes",
+                        "description": "The key(s) must be compatible with the algorithm(s) supported bya TUF client"
                     },
                     "custom": {
                         "type": "object",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1836,7 +1836,7 @@
                         },
                         "type": "object",
                         "title": "Hashes",
-                        "description": "The key(s) must be compatible with the algorithm(s) supported bya TUF client"
+                        "description": "The key(s) must be compatible with the algorithm(s) supported by a TUF client"
                     },
                     "custom": {
                         "type": "object",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -852,6 +852,16 @@
                                 }
                             },
                             "path": "file2.tar.gz"
+                        },
+                        {
+                            "info": {
+                                "length": 39,
+                                "hashes": {
+                                    "sha256": "452ce8308500d83ef44248d8e6062359211992fd837ea9e370e561efb1a4ca99",
+                                    "sha512": "052b49a21e03606b28942db69aa597530fe52d47ee3d748ba65afcd14b857738e36bc1714c4f4adde46c3e683548552fe5c96722e0e0da3acd9050c2524902d8"
+                                }
+                            },
+                            "path": "file3.tar.gz"
                         }
                     ]
                 }

--- a/repository_service_tuf_api/targets.py
+++ b/repository_service_tuf_api/targets.py
@@ -42,16 +42,14 @@ class Response(BaseModel):
         schema_extra = {"example": data_example}
 
 
-class PayloadTargetsHashes(BaseModel):
-    blake2b_256: str
-
-    class Config:
-        fields = {"blake2b_256": "blake2b-256"}
-
-
 class TargetsInfo(BaseModel):
     length: int
-    hashes: PayloadTargetsHashes
+    hashes: Dict[str, str] = Field(
+        description=(
+            "The key(s) must be compatible with the algorithm(s) supported by"
+            "a TUF client"
+        )
+    )
     custom: Optional[Dict[str, Any]]
 
 

--- a/repository_service_tuf_api/targets.py
+++ b/repository_service_tuf_api/targets.py
@@ -46,7 +46,7 @@ class TargetsInfo(BaseModel):
     length: int
     hashes: Dict[str, str] = Field(
         description=(
-            "The key(s) must be compatible with the algorithm(s) supported by"
+            "The key(s) must be compatible with the algorithm(s) supported by "
             "a TUF client"
         )
     )

--- a/tests/data_examples/targets/payload.json
+++ b/tests/data_examples/targets/payload.json
@@ -18,6 +18,16 @@
                 }
             },
             "path": "file2.tar.gz"
+        },
+        {
+            "info": {
+                "length": 39,
+                "hashes": {
+                    "sha256": "452ce8308500d83ef44248d8e6062359211992fd837ea9e370e561efb1a4ca99",
+                    "sha512": "052b49a21e03606b28942db69aa597530fe52d47ee3d748ba65afcd14b857738e36bc1714c4f4adde46c3e683548552fe5c96722e0e0da3acd9050c2524902d8"
+                }
+            },
+            "path": "file3.tar.gz"
         }
     ]
 }

--- a/tests/unit/api/test_targets.py
+++ b/tests/unit/api/test_targets.py
@@ -47,7 +47,7 @@ class TestPostTargets:
         assert response.status_code == status.HTTP_202_ACCEPTED
         assert response.json() == {
             "data": {
-                "targets": ["file1.tar.gz", "file2.tar.gz"],
+                "targets": ["file1.tar.gz", "file2.tar.gz", "file3.tar.gz"],
                 "task_id": fake_task_id,
                 "last_update": "2019-06-16T09:05:01",
             },
@@ -113,7 +113,7 @@ class TestPostTargets:
         assert response.status_code == status.HTTP_202_ACCEPTED
         assert response.json() == {
             "data": {
-                "targets": ["file1.tar.gz", "file2.tar.gz"],
+                "targets": ["file1.tar.gz", "file2.tar.gz", "file3.tar.gz"],
                 "task_id": fake_task_id,
                 "last_update": "2019-06-16T09:05:01",
             },
@@ -190,7 +190,7 @@ class TestPostTargets:
         msg = "Target(s) successfully submitted. Publishing will be skipped."
         assert response.json() == {
             "data": {
-                "targets": ["file1.tar.gz", "file2.tar.gz"],
+                "targets": ["file1.tar.gz", "file2.tar.gz", "file3.tar.gz"],
                 "task_id": fake_task_id,
                 "last_update": "2019-06-16T09:05:01",
             },
@@ -355,7 +355,7 @@ class TestPostTargets:
         assert response.status_code == status.HTTP_202_ACCEPTED
         assert response.json() == {
             "data": {
-                "targets": ["file1.tar.gz", "file2.tar.gz"],
+                "targets": ["file1.tar.gz", "file2.tar.gz", "file3.tar.gz"],
                 "task_id": fake_task_id,
                 "last_update": "2019-06-16T09:05:01",
             },


### PR DESCRIPTION
<!--- Thanks for taking the time to fill out this pull request! -->
<!--- Please fill in the fields below to submit a pull request. 
The more information provided, the better. -->

<!---  -->

# Description
Currently, we limit the hashes algorithms that are used for TargeFiles
to only "blake2b-256" which is limiting as the specification doesn't
limit to particular algorithms.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>


<!--- Please reference the issue(s) this PR fixes. -->
Fixes #379


# Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)


# Additional requirements
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


# Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.rst).

- [x] I agree to follow this project's Code of Conduct