### PR TITLE
Update docker-compose commands by docker compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,14 +28,14 @@ build-dev:
 run-dev:
 	$(MAKE) build-dev
 	docker pull ghcr.io/repository-service-tuf/repository-service-tuf-worker:dev
-	docker-compose up --remove-orphans
+	docker compose up --remove-orphans
 
 stop:
 	docker-compose down -v
 
 clean:
 	$(MAKE) stop
-	docker-compose rm --force
+	docker compose rm --force
 	rm -rf ./data
 	rm -rf ./data_test
 


### PR DESCRIPTION
Update docker-compose commands to use "docker compose"

This PR updates the usage of Docker Compose commands in Makefile to use the new "docker compose" syntax introduced in Docker Compose.

The new syntax offers improved consistency and ease of use.

Changes made:

Replaced occurrences of "docker-compose" with "docker compose".

Closes #392  

# Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)


# Additional requirements
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


# Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.rst).

- [X] I agree to follow this project's Code of Conduct