### PR TITLE
feat: Add a new DELETE /api/v1/metadata/sign endpoint 

### DIFF
--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -315,7 +315,7 @@
                     "v1",
                     "v1"
                 ],
-                "summary": "Delete role metadata in signing process. Scope: delete_metadata",
+                "summary": "Delete role metadata in signing process. Scope: delete:metadata_sign",
                 "description": "Delete role metadata in signing process",
                 "operationId": "delete_sign_api_v1_metadata_sign_delete",
                 "requestBody": {
@@ -356,7 +356,7 @@
                 "security": [
                     {
                         "OAuth2PasswordBearer": [
-                            "delete_metadata"
+                            "delete:metadata_sign"
                         ]
                     }
                 ]
@@ -932,7 +932,7 @@
                     "scope": {
                         "type": "string",
                         "title": "Scope",
-                        "description": "Add scopes separeted by space. Available scopes: `read:bootstrap`, `read:settings`, `read:tasks`, `read:token`, `write:bootstrap`, `write:settings`, `write:metadata`, `read:metadata`, `write:targets`, `write:token`, `delete:targets`, `delete_metadata`"
+                        "description": "Add scopes separeted by space. Available scopes: `read:bootstrap`, `read:settings`, `read:tasks`, `read:token`, `write:bootstrap`, `write:settings`, `write:metadata`, `read:metadata`, `write:targets`, `write:token`, `delete:targets`, `delete:metadata_sign`"
                     },
                     "expires": {
                         "type": "integer",
@@ -1193,7 +1193,7 @@
                             "write:targets",
                             "write:token",
                             "delete:targets",
-                            "delete_metadata"
+                            "delete:metadata_sign"
                         ],
                         "expired": false,
                         "expiration": "2022-08-19T17:29:39"
@@ -2244,7 +2244,7 @@
                             "write:settings": "Write (PUT) settings",
                             "write:metadata": "Write (POST) metadata",
                             "delete:targets": "Delete (DELETE) targets",
-                            "delete_metadata": "Delete (DELETE) metadata"
+                            "delete:metadata_sign": "Delete (DELETE) metadata"
                         },
                         "tokenUrl": "/api/v1/token"
                     }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -309,6 +309,57 @@
                         ]
                     }
                 ]
+            },
+            "delete": {
+                "tags": [
+                    "v1",
+                    "v1"
+                ],
+                "summary": "Delete role metadata in signing process. Scope: delete_metadata",
+                "description": "Delete role metadata in signing process",
+                "operationId": "delete_sign_api_v1_metadata_sign_delete",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetadataSignDeletePayload"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "202": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetadataSignDeleteResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "OAuth2PasswordBearer": [
+                            "delete_metadata"
+                        ]
+                    }
+                ]
             }
         },
         "/api/v1/artifacts/": {
@@ -881,7 +932,7 @@
                     "scope": {
                         "type": "string",
                         "title": "Scope",
-                        "description": "Add scopes separeted by space. Available scopes: `read:bootstrap`, `read:settings`, `read:tasks`, `read:token`, `write:bootstrap`, `write:settings`, `write:metadata`, `read:metadata`, `write:targets`, `write:token`, `delete:targets`"
+                        "description": "Add scopes separeted by space. Available scopes: `read:bootstrap`, `read:settings`, `read:tasks`, `read:token`, `write:bootstrap`, `write:settings`, `write:metadata`, `read:metadata`, `write:targets`, `write:token`, `delete:targets`, `delete_metadata`"
                     },
                     "expires": {
                         "type": "integer",
@@ -1055,6 +1106,16 @@
                     "message": "Bootstrap accepted."
                 }
             },
+            "DeleteData": {
+                "properties": {
+                    "task_id": {
+                        "type": "string",
+                        "title": "Task Id"
+                    }
+                },
+                "type": "object",
+                "title": "DeleteData"
+            },
             "DeletePayload": {
                 "properties": {
                     "targets": {
@@ -1131,7 +1192,8 @@
                             "read:metadata",
                             "write:targets",
                             "write:token",
-                            "delete:targets"
+                            "delete:targets",
+                            "delete_metadata"
                         ],
                         "expired": false,
                         "expiration": "2022-08-19T17:29:39"
@@ -1278,6 +1340,44 @@
                         "task_id": "7a634b556f784ae88785d36425f9a218"
                     },
                     "message": "Metadata Update accepted."
+                }
+            },
+            "MetadataSignDeletePayload": {
+                "properties": {
+                    "role": {
+                        "type": "string",
+                        "title": "Role"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "role"
+                ],
+                "title": "MetadataSignDeletePayload",
+                "example": {
+                    "role": "root"
+                }
+            },
+            "MetadataSignDeleteResponse": {
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/DeleteData"
+                    },
+                    "message": {
+                        "type": "string",
+                        "title": "Message"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "message"
+                ],
+                "title": "MetadataSignDeleteResponse",
+                "example": {
+                    "data": {
+                        "task_id": "7a634b556f784ae88785d36425f9a218"
+                    },
+                    "message": "Metadata delete sign accepted."
                 }
             },
             "MetadataSignGetResponse": {
@@ -2143,7 +2243,8 @@
                             "write:bootstrap": "Write (POST) bootstrap",
                             "write:settings": "Write (PUT) settings",
                             "write:metadata": "Write (POST) metadata",
-                            "delete:targets": "Delete (DELETE) targets"
+                            "delete:targets": "Delete (DELETE) targets",
+                            "delete_metadata": "Delete (DELETE) metadata"
                         },
                         "tokenUrl": "/api/v1/token"
                     }

--- a/repository_service_tuf_api/__init__.py
+++ b/repository_service_tuf_api/__init__.py
@@ -49,7 +49,7 @@ class SCOPES_NAMES(Enum):
     write_targets = "write:targets"
     write_token = "write:token"  # nosec bandit: not hard coded password
     delete_targets = "delete:targets"
-    delete_metadata = "delete_metadata"
+    delete_metadata_sign = "delete:metadata_sign"
 
 
 SCOPES = {
@@ -64,7 +64,7 @@ SCOPES = {
     SCOPES_NAMES.write_settings.value: "Write (PUT) settings",
     SCOPES_NAMES.write_metadata.value: "Write (POST) metadata",
     SCOPES_NAMES.delete_targets.value: "Delete (DELETE) targets",
-    SCOPES_NAMES.delete_metadata.value: "Delete (DELETE) metadata",
+    SCOPES_NAMES.delete_metadata_sign.value: "Delete (DELETE) metadata",
 }
 
 DATA_DIR = os.getenv("DATA_DIR", "/data")

--- a/repository_service_tuf_api/__init__.py
+++ b/repository_service_tuf_api/__init__.py
@@ -49,6 +49,7 @@ class SCOPES_NAMES(Enum):
     write_targets = "write:targets"
     write_token = "write:token"  # nosec bandit: not hard coded password
     delete_targets = "delete:targets"
+    delete_metadata = "delete_metadata"
 
 
 SCOPES = {
@@ -63,6 +64,7 @@ SCOPES = {
     SCOPES_NAMES.write_settings.value: "Write (PUT) settings",
     SCOPES_NAMES.write_metadata.value: "Write (POST) metadata",
     SCOPES_NAMES.delete_targets.value: "Delete (DELETE) targets",
+    SCOPES_NAMES.delete_metadata.value: "Delete (DELETE) metadata",
 }
 
 DATA_DIR = os.getenv("DATA_DIR", "/data")

--- a/repository_service_tuf_api/api/metadata.py
+++ b/repository_service_tuf_api/api/metadata.py
@@ -75,7 +75,7 @@ def post_sign(
     "/sign",
     summary=(
         "Delete role metadata in signing process. Scope: "
-        f"{SCOPES_NAMES.delete_metadata.value}"
+        f"{SCOPES_NAMES.delete_metadata_sign.value}"
     ),
     description="Delete role metadata in signing process",
     response_model=metadata.MetadataSignDeleteResponse,
@@ -84,6 +84,6 @@ def post_sign(
 )
 def delete_sign(
     payload: metadata.MetadataSignDeletePayload,
-    _user=Security(auth, scopes=[SCOPES_NAMES.delete_metadata.value]),
+    _user=Security(auth, scopes=[SCOPES_NAMES.delete_metadata_sign.value]),
 ):
-    return metadata.delete_metada_sign(payload)
+    return metadata.delete_metadata_sign(payload)

--- a/repository_service_tuf_api/api/metadata.py
+++ b/repository_service_tuf_api/api/metadata.py
@@ -69,3 +69,21 @@ def post_sign(
     _user=Security(auth, scopes=[SCOPES_NAMES.write_metadata.value]),
 ):
     return metadata.post_metadata_sign(payload)
+
+
+@router.delete(
+    "/sign",
+    summary=(
+        "Delete role metadata in signing process. Scope: "
+        f"{SCOPES_NAMES.delete_metadata.value}"
+    ),
+    description="Delete role metadata in signing process",
+    response_model=metadata.MetadataSignDeleteResponse,
+    response_model_exclude_none=True,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+def delete_sign(
+    payload: metadata.MetadataSignDeletePayload,
+    _user=Security(auth, scopes=[SCOPES_NAMES.delete_metadata.value]),
+):
+    return metadata.delete_metada_sign(payload)

--- a/repository_service_tuf_api/metadata.py
+++ b/repository_service_tuf_api/metadata.py
@@ -230,7 +230,7 @@ class MetadataSignDeleteResponse(BaseModel):
         schema_extra = {"example": example}
 
 
-def delete_metada_sign(payload: MetadataSignDeletePayload):
+def delete_metadata_sign(payload: MetadataSignDeletePayload):
     role = payload.role
     settings_repository.reload()
     signing_status = settings_repository.get_fresh(f"{role.upper()}_SIGNING")
@@ -255,5 +255,5 @@ def delete_metada_sign(payload: MetadataSignDeletePayload):
     )
 
     return MetadataSignDeleteResponse(
-        data={"task_id": task_id}, message="Metadata delete sign accepted."
+        data={"task_id": task_id}, message="Metadata sign delete accepted."
     )

--- a/repository_service_tuf_api/metadata.py
+++ b/repository_service_tuf_api/metadata.py
@@ -65,7 +65,7 @@ def post_metadata(payload: MetadataPostPayload) -> MetadataPostResponse:
 
     repository_metadata.apply_async(
         kwargs={
-            "action": "metadata_rotation",
+            "action": "metadata_update",
             "payload": payload.dict(by_alias=True, exclude_none=True),
         },
         task_id=task_id,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,7 @@ def token_headers(test_client):
             "read:tasks "
             "write:token "
             "delete:targets "
+            "delete_metadata "
         ),
     }
     token = test_client.post(token_url, data=token_payload)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,7 +36,7 @@ def token_headers(test_client):
             "read:tasks "
             "write:token "
             "delete:targets "
-            "delete_metadata "
+            "delete:metadata_sign "
         ),
     }
     token = test_client.post(token_url, data=token_payload)

--- a/tests/unit/api/test_metadata.py
+++ b/tests/unit/api/test_metadata.py
@@ -372,7 +372,7 @@ class TestPostMetadataSign:
 
 
 class TestDeleteMetadataSign:
-    def test_delete_metadata_sign_no_role(
+    def test_delete_metadata_sign(
         self, test_client, token_headers, monkeypatch
     ):
         url = "/api/v1/metadata/sign/"
@@ -406,7 +406,7 @@ class TestDeleteMetadataSign:
         assert response.status_code == status.HTTP_202_ACCEPTED, response.text
         assert response.json() == {
             "data": {"task_id": "123"},
-            "message": "Metadata delete sign accepted.",
+            "message": "Metadata sign delete accepted.",
         }
         assert mocked_settings_repository.reload.calls == [pretend.call()]
         assert mocked_settings_repository.get_fresh.calls == [


### PR DESCRIPTION
<!--- Thanks for taking the time to fill out this pull request! -->
<!--- Please fill in the fields below to submit a pull request. 
The more information provided, the better. -->

<!---  -->

# Description
<!--- What is the PR about? -->
Add a new `DELETE /api/v1/metadata/sign` endpoint.
The purpose of this endpoint is to give a direct way for repository administrators to stop a DAS ceremony.
This DAS process can be started from both `POST /api/v1/bootstrap` and `POST /api/v1/metadata`.
This will be different than the suggested `PATCH /api/v1/metadata/sign` endpoint as this will give the opportunity to:
1. stop the DAS process immediately and do not risk other maintainers signing the metadata and passing the threshold requirement.
2. take it slow and decide what the new `bootstrap` or `metadata update` should look like


<!--- Please reference the issue(s) this PR fixes. -->
Fixes #420


# Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)


# Additional requirements
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


# Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.rst).

- [x] I agree to follow this project's Code of Conduct