### PR TITLE
Change "sign" API calls scopes more granular

### DIFF
--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -180,7 +180,7 @@
                     "v1",
                     "v1"
                 ],
-                "summary": "Rotate role metadata. Scope: write:metadata",
+                "summary": "Rotate role metadata. Scope: write:metadata_sign",
                 "description": "Rotate a role metadata that requires offline signing.",
                 "operationId": "post_api_v1_metadata__post",
                 "requestBody": {
@@ -221,7 +221,7 @@
                 "security": [
                     {
                         "OAuth2PasswordBearer": [
-                            "write:metadata"
+                            "write:metadata_sign"
                         ]
                     }
                 ]
@@ -233,7 +233,7 @@
                     "v1",
                     "v1"
                 ],
-                "summary": "Get all metadata roles pending signatures. Scope: read:metadata",
+                "summary": "Get all metadata roles pending signatures. Scope: read:metadata_sign",
                 "description": "Get all metadata roles that need more signatures before they can be used.",
                 "operationId": "get_sign_api_v1_metadata_sign_get",
                 "responses": {
@@ -254,7 +254,7 @@
                 "security": [
                     {
                         "OAuth2PasswordBearer": [
-                            "read:metadata"
+                            "read:metadata_sign"
                         ]
                     }
                 ]
@@ -264,7 +264,7 @@
                     "v1",
                     "v1"
                 ],
-                "summary": "Add a signature for a metadata role. Scope: write:metadata",
+                "summary": "Add a signature for a metadata role. Scope: write:metadata_sign",
                 "description": "Add a signature for a metadata role.",
                 "operationId": "post_sign_api_v1_metadata_sign_post",
                 "requestBody": {
@@ -305,7 +305,7 @@
                 "security": [
                     {
                         "OAuth2PasswordBearer": [
-                            "write:metadata"
+                            "write:metadata_sign"
                         ]
                     }
                 ]
@@ -932,7 +932,7 @@
                     "scope": {
                         "type": "string",
                         "title": "Scope",
-                        "description": "Add scopes separeted by space. Available scopes: `read:bootstrap`, `read:settings`, `read:tasks`, `read:token`, `write:bootstrap`, `write:settings`, `write:metadata`, `read:metadata`, `write:targets`, `write:token`, `delete:targets`, `delete:metadata_sign`"
+                        "description": "Add scopes separeted by space. Available scopes: `read:bootstrap`, `read:settings`, `read:tasks`, `read:token`, `write:bootstrap`, `write:settings`, `write:metadata_sign`, `read:metadata_sign`, `write:targets`, `write:token`, `delete:targets`, `delete:metadata_sign`"
                     },
                     "expires": {
                         "type": "integer",
@@ -1188,8 +1188,8 @@
                             "read:token",
                             "write:bootstrap",
                             "write:settings",
-                            "write:metadata",
-                            "read:metadata",
+                            "write:metadata_sign",
+                            "read:metadata_sign",
                             "write:targets",
                             "write:token",
                             "delete:targets",
@@ -2009,10 +2009,10 @@
                                 "read:settings",
                                 "read:tasks",
                                 "read:token",
-                                "read:metadata",
+                                "read:metadata_sign",
                                 "write:targets",
                                 "write:settings",
-                                "write:metadata",
+                                "write:metadata_sign",
                                 "delete:targets"
                             ]
                         },
@@ -2237,12 +2237,12 @@
                             "read:settings": "Read (GET) settings",
                             "read:tasks": "Read (GET) tasks",
                             "read:token": "Read (GET) tokens",
-                            "read:metadata": "Read (GET) metadata",
+                            "read:metadata_sign": "Read (GET) metadata",
                             "write:targets": "Write (POST) targets",
                             "write:token": "Write (POST) token",
                             "write:bootstrap": "Write (POST) bootstrap",
                             "write:settings": "Write (PUT) settings",
-                            "write:metadata": "Write (POST) metadata",
+                            "write:metadata_sign": "Write (POST) metadata",
                             "delete:targets": "Delete (DELETE) targets",
                             "delete:metadata_sign": "Delete (DELETE) metadata"
                         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -2015,7 +2015,8 @@
                                 "write:settings",
                                 "write:metadata",
                                 "write:metadata_sign",
-                                "delete:targets"
+                                "delete:targets",
+                                "delete:metadata_sign"
                             ]
                         },
                         "type": "array",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -180,7 +180,7 @@
                     "v1",
                     "v1"
                 ],
-                "summary": "Rotate role metadata. Scope: write:metadata_sign",
+                "summary": "Rotate role metadata. Scope: write:metadata",
                 "description": "Rotate a role metadata that requires offline signing.",
                 "operationId": "post_api_v1_metadata__post",
                 "requestBody": {
@@ -221,7 +221,7 @@
                 "security": [
                     {
                         "OAuth2PasswordBearer": [
-                            "write:metadata_sign"
+                            "write:metadata"
                         ]
                     }
                 ]
@@ -932,7 +932,7 @@
                     "scope": {
                         "type": "string",
                         "title": "Scope",
-                        "description": "Add scopes separeted by space. Available scopes: `read:bootstrap`, `read:settings`, `read:tasks`, `read:token`, `write:bootstrap`, `write:settings`, `write:metadata_sign`, `read:metadata_sign`, `write:targets`, `write:token`, `delete:targets`, `delete:metadata_sign`"
+                        "description": "Add scopes separeted by space. Available scopes: `read:bootstrap`, `read:settings`, `read:tasks`, `read:token`, `write:bootstrap`, `write:settings`, `write:metadata`, `write:metadata_sign`, `read:metadata_sign`, `write:targets`, `write:token`, `delete:targets`, `delete:metadata_sign`"
                     },
                     "expires": {
                         "type": "integer",
@@ -1188,6 +1188,7 @@
                             "read:token",
                             "write:bootstrap",
                             "write:settings",
+                            "write:metadata",
                             "write:metadata_sign",
                             "read:metadata_sign",
                             "write:targets",
@@ -2012,6 +2013,7 @@
                                 "read:metadata_sign",
                                 "write:targets",
                                 "write:settings",
+                                "write:metadata",
                                 "write:metadata_sign",
                                 "delete:targets"
                             ]
@@ -2242,7 +2244,8 @@
                             "write:token": "Write (POST) token",
                             "write:bootstrap": "Write (POST) bootstrap",
                             "write:settings": "Write (PUT) settings",
-                            "write:metadata_sign": "Write (POST) metadata",
+                            "write:metadata": "Write (POST) metadata",
+                            "write:metadata_sign": "Write (POST) metadata sign",
                             "delete:targets": "Delete (DELETE) targets",
                             "delete:metadata_sign": "Delete (DELETE) metadata"
                         },

--- a/repository_service_tuf_api/__init__.py
+++ b/repository_service_tuf_api/__init__.py
@@ -44,8 +44,8 @@ class SCOPES_NAMES(Enum):
     read_token = "read:token"  # nosec bandit: not hard coded password
     write_bootstrap = "write:bootstrap"
     write_settings = "write:settings"
-    write_metadata = "write:metadata"
-    read_metadata = "read:metadata"
+    write_metadata_sign = "write:metadata_sign"
+    read_metadata_sign = "read:metadata_sign"
     write_targets = "write:targets"
     write_token = "write:token"  # nosec bandit: not hard coded password
     delete_targets = "delete:targets"
@@ -57,12 +57,12 @@ SCOPES = {
     SCOPES_NAMES.read_settings.value: "Read (GET) settings",
     SCOPES_NAMES.read_tasks.value: "Read (GET) tasks",
     SCOPES_NAMES.read_token.value: "Read (GET) tokens",
-    SCOPES_NAMES.read_metadata.value: "Read (GET) metadata",
+    SCOPES_NAMES.read_metadata_sign.value: "Read (GET) metadata",
     SCOPES_NAMES.write_targets.value: "Write (POST) targets",
     SCOPES_NAMES.write_token.value: "Write (POST) token",
     SCOPES_NAMES.write_bootstrap.value: "Write (POST) bootstrap",
     SCOPES_NAMES.write_settings.value: "Write (PUT) settings",
-    SCOPES_NAMES.write_metadata.value: "Write (POST) metadata",
+    SCOPES_NAMES.write_metadata_sign.value: "Write (POST) metadata",
     SCOPES_NAMES.delete_targets.value: "Delete (DELETE) targets",
     SCOPES_NAMES.delete_metadata_sign.value: "Delete (DELETE) metadata",
 }

--- a/repository_service_tuf_api/__init__.py
+++ b/repository_service_tuf_api/__init__.py
@@ -44,6 +44,7 @@ class SCOPES_NAMES(Enum):
     read_token = "read:token"  # nosec bandit: not hard coded password
     write_bootstrap = "write:bootstrap"
     write_settings = "write:settings"
+    write_metadata = "write:metadata"
     write_metadata_sign = "write:metadata_sign"
     read_metadata_sign = "read:metadata_sign"
     write_targets = "write:targets"
@@ -62,7 +63,8 @@ SCOPES = {
     SCOPES_NAMES.write_token.value: "Write (POST) token",
     SCOPES_NAMES.write_bootstrap.value: "Write (POST) bootstrap",
     SCOPES_NAMES.write_settings.value: "Write (PUT) settings",
-    SCOPES_NAMES.write_metadata_sign.value: "Write (POST) metadata",
+    SCOPES_NAMES.write_metadata.value: "Write (POST) metadata",
+    SCOPES_NAMES.write_metadata_sign.value: "Write (POST) metadata sign",
     SCOPES_NAMES.delete_targets.value: "Delete (DELETE) targets",
     SCOPES_NAMES.delete_metadata_sign.value: "Delete (DELETE) metadata",
 }

--- a/repository_service_tuf_api/api/metadata.py
+++ b/repository_service_tuf_api/api/metadata.py
@@ -19,7 +19,7 @@ auth = get_auth()
 @router.post(
     "/",
     summary=(
-        f"Rotate role metadata. Scope: " f"{SCOPES_NAMES.write_metadata.value}"
+        f"Rotate role metadata. Scope: {SCOPES_NAMES.write_metadata.value}"
     ),
     description=("Rotate a role metadata that requires offline signing."),
     response_model=metadata.MetadataPostResponse,

--- a/repository_service_tuf_api/api/metadata.py
+++ b/repository_service_tuf_api/api/metadata.py
@@ -19,8 +19,7 @@ auth = get_auth()
 @router.post(
     "/",
     summary=(
-        f"Rotate role metadata. Scope: "
-        f"{SCOPES_NAMES.write_metadata_sign.value}"
+        f"Rotate role metadata. Scope: " f"{SCOPES_NAMES.write_metadata.value}"
     ),
     description=("Rotate a role metadata that requires offline signing."),
     response_model=metadata.MetadataPostResponse,
@@ -29,7 +28,7 @@ auth = get_auth()
 )
 def post(
     payload: metadata.MetadataPostPayload,
-    _user=Security(auth, scopes=[SCOPES_NAMES.write_metadata_sign.value]),
+    _user=Security(auth, scopes=[SCOPES_NAMES.write_metadata.value]),
 ):
     return metadata.post_metadata(payload)
 

--- a/repository_service_tuf_api/api/metadata.py
+++ b/repository_service_tuf_api/api/metadata.py
@@ -19,7 +19,8 @@ auth = get_auth()
 @router.post(
     "/",
     summary=(
-        f"Rotate role metadata. Scope: {SCOPES_NAMES.write_metadata.value}"
+        f"Rotate role metadata. Scope: "
+        f"{SCOPES_NAMES.write_metadata_sign.value}"
     ),
     description=("Rotate a role metadata that requires offline signing."),
     response_model=metadata.MetadataPostResponse,
@@ -28,7 +29,7 @@ auth = get_auth()
 )
 def post(
     payload: metadata.MetadataPostPayload,
-    _user=Security(auth, scopes=[SCOPES_NAMES.write_metadata.value]),
+    _user=Security(auth, scopes=[SCOPES_NAMES.write_metadata_sign.value]),
 ):
     return metadata.post_metadata(payload)
 
@@ -37,7 +38,7 @@ def post(
     "/sign",
     summary=(
         "Get all metadata roles pending signatures. Scope: "
-        f"{SCOPES_NAMES.read_metadata.value}"
+        f"{SCOPES_NAMES.read_metadata_sign.value}"
     ),
     description=(
         "Get all metadata roles that need more signatures before they can be "
@@ -48,7 +49,7 @@ def post(
     status_code=status.HTTP_200_OK,
 )
 def get_sign(
-    _user=Security(auth, scopes=[SCOPES_NAMES.read_metadata.value]),
+    _user=Security(auth, scopes=[SCOPES_NAMES.read_metadata_sign.value]),
 ):
     return metadata.get_metadata_sign()
 
@@ -57,7 +58,7 @@ def get_sign(
     "/sign",
     summary=(
         "Add a signature for a metadata role. Scope: "
-        f"{SCOPES_NAMES.write_metadata.value}"
+        f"{SCOPES_NAMES.write_metadata_sign.value}"
     ),
     description=("Add a signature for a metadata role."),
     response_model=metadata.MetadataPostResponse,
@@ -66,7 +67,7 @@ def get_sign(
 )
 def post_sign(
     payload: metadata.MetadataSignPostPayload,
-    _user=Security(auth, scopes=[SCOPES_NAMES.write_metadata.value]),
+    _user=Security(auth, scopes=[SCOPES_NAMES.write_metadata_sign.value]),
 ):
     return metadata.post_metadata_sign(payload)
 

--- a/repository_service_tuf_api/token.py
+++ b/repository_service_tuf_api/token.py
@@ -92,6 +92,7 @@ class TokenRequestPayload(BaseModel):
             SCOPES_NAMES.read_metadata_sign.value,
             SCOPES_NAMES.write_targets.value,
             SCOPES_NAMES.write_settings.value,
+            SCOPES_NAMES.write_metadata.value,
             SCOPES_NAMES.write_metadata_sign.value,
             SCOPES_NAMES.delete_targets.value,
         ]

--- a/repository_service_tuf_api/token.py
+++ b/repository_service_tuf_api/token.py
@@ -89,10 +89,10 @@ class TokenRequestPayload(BaseModel):
             SCOPES_NAMES.read_settings.value,
             SCOPES_NAMES.read_tasks.value,
             SCOPES_NAMES.read_token.value,
-            SCOPES_NAMES.read_metadata.value,
+            SCOPES_NAMES.read_metadata_sign.value,
             SCOPES_NAMES.write_targets.value,
             SCOPES_NAMES.write_settings.value,
-            SCOPES_NAMES.write_metadata.value,
+            SCOPES_NAMES.write_metadata_sign.value,
             SCOPES_NAMES.delete_targets.value,
         ]
     ] = Field(min_items=1)

--- a/repository_service_tuf_api/token.py
+++ b/repository_service_tuf_api/token.py
@@ -95,6 +95,7 @@ class TokenRequestPayload(BaseModel):
             SCOPES_NAMES.write_metadata.value,
             SCOPES_NAMES.write_metadata_sign.value,
             SCOPES_NAMES.delete_targets.value,
+            SCOPES_NAMES.delete_metadata_sign.value,
         ]
     ] = Field(min_items=1)
     expires: int = Field(description="In hour(s)", ge=1)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,8 +27,8 @@ def token_headers(test_client):
         "scope": (
             "write:targets "
             "write:bootstrap "
-            "write:metadata "
-            "read:metadata "
+            "write:metadata_sign "
+            "read:metadata_sign "
             "read:bootstrap "
             "write:settings "
             "read:settings "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,7 @@ def token_headers(test_client):
         "scope": (
             "write:targets "
             "write:bootstrap "
+            "write:metadata "
             "write:metadata_sign "
             "read:metadata_sign "
             "read:bootstrap "

--- a/tests/unit/api/test_metadata.py
+++ b/tests/unit/api/test_metadata.py
@@ -166,7 +166,7 @@ class TestPostMetadata:
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
         assert response.json() == {
-            "detail": {"error": "scope 'write:metadata_sign' not allowed"}
+            "detail": {"error": "scope 'write:metadata' not allowed"}
         }
 
     def test_post_payload_incorrect_md_format(

--- a/tests/unit/api/test_metadata.py
+++ b/tests/unit/api/test_metadata.py
@@ -166,7 +166,7 @@ class TestPostMetadata:
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
         assert response.json() == {
-            "detail": {"error": "scope 'write:metadata' not allowed"}
+            "detail": {"error": "scope 'write:metadata_sign' not allowed"}
         }
 
     def test_post_payload_incorrect_md_format(


### PR DESCRIPTION
<!--- Thanks for taking the time to fill out this pull request! -->
<!--- Please fill in the fields below to submit a pull request. 
The more information provided, the better. -->

<!---  -->

# Description
<!--- What is the PR about? -->

Change "sign" API calls scopes more granular.
This allows for future scope `metadata` related scopes which will have a different semantics.
Also, this allows an organization to have a finer control over which of its maintainers can start or stop a DAS process through the `write:metadata_sign` and `delete:metadata_sign` scopes.

Related to those changes: https://github.com/repository-service-tuf/repository-service-tuf-cli/pull/366

Closes #434 

# Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)


# Additional requirements
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


# Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.rst).

- [ ] I agree to follow this project's Code of Conduct