### PR TITLE
Fix bootstrap_state checks in two places

### DIFF
--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1155,6 +1155,10 @@
                     "state": {
                         "type": "string",
                         "title": "State"
+                    },
+                    "id": {
+                        "type": "string",
+                        "title": "Id"
                     }
                 },
                 "type": "object",

--- a/repository_service_tuf_api/__init__.py
+++ b/repository_service_tuf_api/__init__.py
@@ -240,8 +240,8 @@ def bootstrap_state() -> BootstrapState:
         return bootstrap_state
 
     elif len(bootstrap.split("-")) == 2:
-        # This is considered an intermediated state It is not finished because
-        # there is a `<state>-`
+        # This is considered an intermediated state. It is not finished because
+        # there is a `<state>-` like 'pre-<task_id>' or 'signing-<task_id>'.
         bootstrap_state.bootstrap = False
         bootstrap_state.state = bootstrap.split("-")[0]
         bootstrap_state.task_id = bootstrap.split("-")[1]

--- a/tests/unit/api/test_bootstrap.py
+++ b/tests/unit/api/test_bootstrap.py
@@ -49,7 +49,55 @@ class TestGetBootstrap:
         assert response.status_code == status.HTTP_200_OK
         assert response.url == f"{test_client.base_url}{url}"
         assert response.json() == {
-            "data": {"bootstrap": True, "state": "finished"},
+            "data": {"bootstrap": True, "state": "finished", "id": "task_id"},
+            "message": "System LOCKED for bootstrap.",
+        }
+        assert mocked_bootstrap_state.calls == [pretend.call()]
+
+    def test_get_bootstrap_already_bootstrap_in_pre(
+        self, test_client, monkeypatch, token_headers
+    ):
+        url = "/api/v1/bootstrap/"
+
+        mocked_bootstrap_state = pretend.call_recorder(
+            lambda *a: pretend.stub(
+                bootstrap=False, state="pre", task_id="task_id"
+            )
+        )
+        monkeypatch.setattr(
+            "repository_service_tuf_api.bootstrap.bootstrap_state",
+            mocked_bootstrap_state,
+        )
+
+        response = test_client.get(url, headers=token_headers)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.url == f"{test_client.base_url}{url}"
+        assert response.json() == {
+            "data": {"bootstrap": False, "state": "pre", "id": "task_id"},
+            "message": "System LOCKED for bootstrap.",
+        }
+        assert mocked_bootstrap_state.calls == [pretend.call()]
+
+    def test_get_bootstrap_already_bootstrap_in_signing(
+        self, test_client, monkeypatch, token_headers
+    ):
+        url = "/api/v1/bootstrap/"
+
+        mocked_bootstrap_state = pretend.call_recorder(
+            lambda *a: pretend.stub(
+                bootstrap=False, state="signing", task_id="task_id"
+            )
+        )
+        monkeypatch.setattr(
+            "repository_service_tuf_api.bootstrap.bootstrap_state",
+            mocked_bootstrap_state,
+        )
+
+        response = test_client.get(url, headers=token_headers)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.url == f"{test_client.base_url}{url}"
+        assert response.json() == {
+            "data": {"bootstrap": False, "state": "signing", "id": "task_id"},
             "message": "System LOCKED for bootstrap.",
         }
         assert mocked_bootstrap_state.calls == [pretend.call()]
@@ -90,7 +138,9 @@ class TestPostBootstrap:
         url = "/api/v1/bootstrap/"
 
         mocked_bootstrap_state = pretend.call_recorder(
-            lambda *a: pretend.stub(bootstrap=False)
+            lambda *a: pretend.stub(
+                bootstrap=False, state="finished", task_id="task_id"
+            )
         )
         monkeypatch.setattr(
             "repository_service_tuf_api.bootstrap.bootstrap_state",
@@ -141,7 +191,9 @@ class TestPostBootstrap:
         url = "/api/v1/bootstrap/"
 
         mocked_bootstrap_state = pretend.call_recorder(
-            lambda *a: pretend.stub(bootstrap=False)
+            lambda *a: pretend.stub(
+                bootstrap=False, state="finished", task_id="task_id"
+            )
         )
         monkeypatch.setattr(
             "repository_service_tuf_api.bootstrap.bootstrap_state",
@@ -223,7 +275,7 @@ class TestPostBootstrap:
 
         mocked_bootstrap_state = pretend.call_recorder(
             lambda *a: pretend.stub(
-                bootstrap=True, state="pre", task_id="task_id"
+                bootstrap=False, state="pre", task_id="task_id"
             )
         )
         monkeypatch.setattr(
@@ -250,7 +302,7 @@ class TestPostBootstrap:
 
         mocked_bootstrap_state = pretend.call_recorder(
             lambda *a: pretend.stub(
-                bootstrap=True, state="signing", task_id="task_id"
+                bootstrap=False, state="signing", task_id="task_id"
             )
         )
         monkeypatch.setattr(


### PR DESCRIPTION
<!--- Thanks for taking the time to fill out this pull request! -->
<!--- Please fill in the fields below to submit a pull request. 
The more information provided, the better. -->

<!---  -->

# Description
<!--- What is the PR about? -->
Fix the bootstrap_state checks in `post_bootstrap` and `get_bootstrap`. This makes sure that we say there is a metadata when:
- bootstrap is executed in the moment ("pre" state)
- bootstrap is in a signing process ("signing" state)

Also, fix some small things like "task_id" not sent when calling "get_bootstrap".

Added unit tests for "get_bootstrap" to make sure this mistake can be easily noticed if it happens again, for "post_bootstrap" there are tests already implemented.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>

<!--- Please reference the issue(s) this PR fixes. -->
Fixes #417 


# Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)


# Additional requirements
- [x] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


# Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.rst).

- [x] I agree to follow this project's Code of Conduct