### PR TITLE
Refactor DELETE /api/v1/metadata/sign

### DIFF
--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -309,15 +309,17 @@
                         ]
                     }
                 ]
-            },
-            "delete": {
+            }
+        },
+        "/api/v1/metadata/sign/delete": {
+            "post": {
                 "tags": [
                     "v1",
                     "v1"
                 ],
                 "summary": "Delete role metadata in signing process. Scope: delete:metadata_sign",
                 "description": "Delete role metadata in signing process",
-                "operationId": "delete_sign_api_v1_metadata_sign_delete",
+                "operationId": "post_delete_sign_api_v1_metadata_sign_delete_post",
                 "requestBody": {
                     "content": {
                         "application/json": {

--- a/repository_service_tuf_api/api/metadata.py
+++ b/repository_service_tuf_api/api/metadata.py
@@ -71,8 +71,8 @@ def post_sign(
     return metadata.post_metadata_sign(payload)
 
 
-@router.delete(
-    "/sign",
+@router.post(
+    "/sign/delete",
     summary=(
         "Delete role metadata in signing process. Scope: "
         f"{SCOPES_NAMES.delete_metadata_sign.value}"
@@ -82,7 +82,7 @@ def post_sign(
     response_model_exclude_none=True,
     status_code=status.HTTP_202_ACCEPTED,
 )
-def delete_sign(
+def post_delete_sign(
     payload: metadata.MetadataSignDeletePayload,
     _user=Security(auth, scopes=[SCOPES_NAMES.delete_metadata_sign.value]),
 ):

--- a/tests/unit/api/test_metadata.py
+++ b/tests/unit/api/test_metadata.py
@@ -371,11 +371,11 @@ class TestPostMetadataSign:
         assert mocked_bootstrap_state.calls == [pretend.call()]
 
 
-class TestDeleteMetadataSign:
-    def test_delete_metadata_sign(
+class TestPostMetadataSignDelete:
+    def test_post_metadata_sign_delete(
         self, test_client, token_headers, monkeypatch
     ):
-        url = "/api/v1/metadata/sign/"
+        url = "/api/v1/metadata/sign/delete"
         mocked_settings_repository = pretend.stub(
             reload=pretend.call_recorder(lambda: None),
             get_fresh=pretend.call_recorder(lambda *a: "metadata"),
@@ -399,10 +399,7 @@ class TestDeleteMetadataSign:
         )
         payload = {"role": "root"}
 
-        # https://github.com/tiangolo/fastapi/issues/5649
-        response = test_client.request(
-            "DELETE", url, json=payload, headers=token_headers
-        )
+        response = test_client.post(url, json=payload, headers=token_headers)
         assert response.status_code == status.HTTP_202_ACCEPTED, response.text
         assert response.json() == {
             "data": {"task_id": "123"},
@@ -425,10 +422,10 @@ class TestDeleteMetadataSign:
             )
         ]
 
-    def test_delete_metadata_sign_role_not_in_signing_status(
+    def test_metadata_sign_delete_role_not_in_signing_status(
         self, test_client, token_headers, monkeypatch
     ):
-        url = "/api/v1/metadata/sign/"
+        url = "/api/v1/metadata/sign/delete"
         mocked_settings_repository = pretend.stub(
             reload=pretend.call_recorder(lambda: None),
             get_fresh=pretend.call_recorder(lambda *a: None),
@@ -440,10 +437,7 @@ class TestDeleteMetadataSign:
 
         payload = {"role": "root"}
 
-        # https://github.com/tiangolo/fastapi/issues/5649
-        response = test_client.request(
-            "DELETE", url, json=payload, headers=token_headers
-        )
+        response = test_client.post(url, json=payload, headers=token_headers)
         assert response.status_code == status.HTTP_200_OK, response.text
         assert response.json() == {
             "detail": {


### PR DESCRIPTION
<!--- Thanks for taking the time to fill out this pull request! -->
<!--- Please fill in the fields below to submit a pull request. 
The more information provided, the better. -->

<!---  -->

# Description
<!--- What is the PR about? -->
Add a refactoring of `DELETE /api/v1/metadata/sign` with body payload to a `POST /api/v1/metadata/sign/delete`.

It makes the RSTUF API more compatible with OpenAPI and HTTP specifications, avoiding the body in the DELETE method.

Also, the current implementation is asynchronous, making adding a post more semantical as the resource is not deleted instantly.


<!--- Please reference the issue(s) this PR fixes. -->
Closes #464


# Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality not to work as expected)


# Additional requirements
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


# Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.rst).

- [x] I agree to follow this project's Code of Conduct