### PR TITLE
Changes artifacts DELETE to POST

### DIFF
--- a/docs/source/guide/Docker_README.md
+++ b/docs/source/guide/Docker_README.md
@@ -76,16 +76,16 @@ This variable receives a list separetad by `:`.
 
 You can disable a whole endpoint.
 For example:
-`RSTUF_DISABLED_ENDPOINTS = "/api/v1/targets"`
-Will disable all methods and all paths  related to v1 `targets`:
-GET `/api/v1/targets`, POST `/api/v1/targets`, POST `/api/v1/targets/publish` etc.
+`RSTUF_DISABLED_ENDPOINTS = "/api/v1/artifacts"`
+Will disable all methods and all paths  related to v1 `artifacts`:
+GET `/api/v1/artifacts`, POST `/api/v1/artifacts`, POST `/api/v1/artifacts/publish` etc.
 
 It is possible to disable a specific method endpoint with:
-`{'POST'}/api/v1/targets/publish`.
+`{'POST'}/api/v1/artifacts/publish`.
 
 Note: If you give both
-`RSTUF_DISABLE_ENDPOINTS={'POST'}/api/v1/targets/publish:/api/v1/targets` then
-the `/api/v1/targets` has a higher priority and will disable all v1 targets related endpoints.
+`RSTUF_DISABLE_ENDPOINTS={'POST'}/api/v1/artifacts/publish:/api/v1/artifacts` then
+the `/api/v1/artifacts` has a higher priority and will disable all v1 artifacts related endpoints.
 
 A list can be given as shown in the example bellow:
 `RSTUF_DISABLE_ENDPOINTS={'POST'}/api/v1/bootstrap/:/api/v1/metadata/:/api/v1/artifacts/:{'POST'}/api/v1/metadata/sign/`

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -352,15 +352,17 @@
                         }
                     }
                 }
-            },
-            "delete": {
+            }
+        },
+        "/api/v1/artifacts/delete": {
+            "post": {
                 "tags": [
                     "v1",
                     "v1"
                 ],
-                "summary": "Remove artifacts from Metadata.",
+                "summary": "Remove artifacts from Metadata. ",
                 "description": "Remove artifacts from Metadata.",
-                "operationId": "delete_api_v1_artifacts__delete",
+                "operationId": "post_delete_api_v1_artifacts_delete_post",
                 "requestBody": {
                     "content": {
                         "application/json": {

--- a/repository_service_tuf_api/api/targets.py
+++ b/repository_service_tuf_api/api/targets.py
@@ -32,15 +32,15 @@ def post(payload: targets.AddPayload):
     return response
 
 
-@router.delete(
-    "/",
-    summary="Remove artifacts from Metadata.",
+@router.post(
+    "/delete",
+    summary="Remove artifacts from Metadata. ",
     description="Remove artifacts from Metadata.",
     response_model=targets.Response,
     response_model_exclude_none=True,
     status_code=status.HTTP_202_ACCEPTED,
 )
-def delete(payload: targets.DeletePayload):
+def post_delete(payload: targets.DeletePayload):
     response = targets.delete(payload)
 
     return response

--- a/tests/unit/api/test_targets.py
+++ b/tests/unit/api/test_targets.py
@@ -277,9 +277,9 @@ class TestPostTargets:
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
 
-class TestDeleteTargets:
-    def test_delete(self, monkeypatch, test_client):
-        url = "/api/v1/artifacts/"
+class TestPostTargetsDelete:
+    def test_post_delete(self, monkeypatch, test_client):
+        url = "/api/v1/artifacts/delete"
 
         payload = {
             "targets": ["file-v1.0.0_i683.tar.gz", "v0.4.1/file.tar.gz"],
@@ -312,8 +312,7 @@ class TestDeleteTargets:
             "repository_service_tuf_api.targets.datetime", fake_datetime
         )
 
-        # https://github.com/tiangolo/fastapi/issues/5649
-        response = test_client.request("DELETE", url, json=payload)
+        response = test_client.post(url, json=payload)
 
         assert response.status_code == status.HTTP_202_ACCEPTED
         assert response.json() == {
@@ -337,8 +336,8 @@ class TestDeleteTargets:
             )
         ]
 
-    def test_delete_publish_targets_false(self, monkeypatch, test_client):
-        url = "/api/v1/artifacts/"
+    def test_post_publish_targets_delete_false(self, monkeypatch, test_client):
+        url = "/api/v1/artifacts/delete"
 
         payload = {
             "targets": ["file-v1.0.0_i683.tar.gz", "v0.4.1/file.tar.gz"],
@@ -372,8 +371,7 @@ class TestDeleteTargets:
             "repository_service_tuf_api.targets.datetime", fake_datetime
         )
 
-        # https://github.com/tiangolo/fastapi/issues/5649
-        response = test_client.request("DELETE", url, json=payload)
+        response = test_client.post(url, json=payload)
 
         assert response.status_code == status.HTTP_202_ACCEPTED
         msg = (
@@ -401,8 +399,8 @@ class TestDeleteTargets:
             )
         ]
 
-    def test_delete_without_bootstrap(self, monkeypatch, test_client):
-        url = "/api/v1/artifacts/"
+    def test_post_without_bootstrap_delete(self, monkeypatch, test_client):
+        url = "/api/v1/artifacts/delete"
 
         payload = {
             "targets": ["file-v1.0.0_i683.tar.gz", "v0.4.1/file.tar.gz"]
@@ -414,8 +412,7 @@ class TestDeleteTargets:
             "repository_service_tuf_api.targets.bootstrap_state",
             mocked_bootstrap_state,
         )
-        # https://github.com/tiangolo/fastapi/issues/5649
-        response = test_client.request("DELETE", url, json=payload)
+        response = test_client.post(url, json=payload)
 
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == {
@@ -426,10 +423,10 @@ class TestDeleteTargets:
         }
         assert mocked_bootstrap_state.calls == [pretend.call()]
 
-    def test_delete_with_bootstrap_intermediate_state(
+    def test_post_with_bootstrap_intermediate_state_delete(
         self, monkeypatch, test_client
     ):
-        url = "/api/v1/artifacts/"
+        url = "/api/v1/artifacts/delete"
 
         payload = {
             "targets": ["file-v1.0.0_i683.tar.gz", "v0.4.1/file.tar.gz"]
@@ -441,8 +438,7 @@ class TestDeleteTargets:
             "repository_service_tuf_api.targets.bootstrap_state",
             mocked_bootstrap_state,
         )
-        # https://github.com/tiangolo/fastapi/issues/5649
-        response = test_client.request("DELETE", url, json=payload)
+        response = test_client.post(url, json=payload)
 
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == {
@@ -452,13 +448,12 @@ class TestDeleteTargets:
             }
         }
 
-    def test_delete_missing_required_field(self, test_client):
-        url = "/api/v1/artifacts/"
+    def test_post_missing_required_field_delete(self, test_client):
+        url = "/api/v1/artifacts/delete"
 
         payload = {"paths": ["file-v1.0.0_i683.tar.gz", "v0.4.1/file.tar.gz"]}
 
-        # https://github.com/tiangolo/fastapi/issues/5649
-        response = test_client.request("DELETE", url, json=payload)
+        response = test_client.post(url, json=payload)
 
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 


### PR DESCRIPTION
This changes the artifacts DELETE method to POST. It also updates the docker documentation by changing the targets references to artifacts.

Closes #462

<!--- Thanks for taking the time to fill out this pull request! -->
<!--- Please fill in the fields below to submit a pull request. 
The more information provided, the better. -->

<!---  -->

# Description
<!--- What is the PR about? -->


<!--- Please reference the issue(s) this PR fixes. -->
Fixes #(issue)


# Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality not to work as expected)


# Additional requirements
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


# Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.rst).

- [ ] I agree to follow this project's Code of Conduct