### PR TITLE
Add support for `PUT /api/v1/metadata/online`

### DIFF
--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -194,7 +194,7 @@
                 ],
                 "summary": "Force a new version of online metadata role(s).",
                 "description": "Force a new version of online metadata role(s). If the roles list is empty all roles will be updated. The new metadata version(s) will have extended expiration which will equal to: today + ROLE_NAME_EXPIRATION number of days, where ROLE_NAME_EXPIRATION is a tuf repository setting. Note: depending on which metadata role you want to update other online roles will likely be updated as well otherwise consistency will be lost.",
-                "operationId": "post_api_v1_metadata_online_post",
+                "operationId": "post_online_api_v1_metadata_online_post",
                 "requestBody": {
                     "content": {
                         "application/json": {
@@ -975,13 +975,7 @@
                 "properties": {
                     "roles": {
                         "items": {
-                            "type": "string",
-                            "enum": [
-                                "targets",
-                                "snapshot",
-                                "timestamp",
-                                "bins"
-                            ]
+                            "type": "string"
                         },
                         "type": "array",
                         "title": "Roles"
@@ -991,7 +985,13 @@
                 "required": [
                     "roles"
                 ],
-                "title": "MetadataOnlinePostPayload"
+                "title": "MetadataOnlinePostPayload",
+                "example": {
+                    "roles": [
+                        "targets",
+                        "snapshot"
+                    ]
+                }
             },
             "MetadataOnlinePostResponse": {
                 "properties": {
@@ -1015,7 +1015,14 @@
                     "data",
                     "message"
                 ],
-                "title": "MetadataOnlinePostResponse"
+                "title": "MetadataOnlinePostResponse",
+                "example": {
+                    "data": {
+                        "last_update": "2022-12-01T12:10:00.578086",
+                        "task_id": "7a634b556f784ae88785d36425f9a218"
+                    },
+                    "message": "Force new online metadata accepted."
+                }
             },
             "MetadataPostPayload": {
                 "properties": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -143,6 +143,49 @@
             }
         },
         "/api/v1/metadata/": {
+            "put": {
+                "tags": [
+                    "Metadata"
+                ],
+                "summary": "Force a new version of online metadata role(s).",
+                "description": "Force a new version of online metadata role(s). The new metadata version(s) will have extended expiration which will equal to: today + ROLE_NAME_EXPIRATION number of days, where ROLE_NAME_EXPIRATION is a tuf repository setting. Note: depending on which metadata role you want to update other online roles will likely be updated as well otherwise consistency will be lost.",
+                "operationId": "put_api_v1_metadata__put",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetadataPutPayload"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "202": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetadataPutResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
             "post": {
                 "tags": [
                     "Metadata"
@@ -1084,6 +1127,58 @@
                         "last_update": "2022-12-01T12:10:00.578086",
                         "task_id": "7a634b556f784ae88785d36425f9a218"
                     }
+                }
+            },
+            "MetadataPutPayload": {
+                "properties": {
+                    "roles": {
+                        "items": {
+                            "type": "string",
+                            "enum": [
+                                "root",
+                                "targets",
+                                "snapshot",
+                                "timestamp",
+                                "bins"
+                            ]
+                        },
+                        "type": "array",
+                        "title": "Roles"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "roles"
+                ],
+                "title": "MetadataPutPayload",
+                "example": {
+                    "roles": [
+                        "targets",
+                        "snapshot"
+                    ]
+                }
+            },
+            "MetadataPutResponse": {
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/TaskData"
+                    },
+                    "message": {
+                        "type": "string",
+                        "title": "Message"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "message"
+                ],
+                "title": "MetadataPutResponse",
+                "example": {
+                    "data": {
+                        "task_id": "7a634b556f784ae88785d36425f9a218",
+                        "last_update": "2022-12-01T12:10:00.578086"
+                    },
+                    "message": "Force new online metadata accepted."
                 }
             },
             "MetadataSignDeletePayload": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -148,7 +148,7 @@
                     "Metadata"
                 ],
                 "summary": "Force a new version of online metadata role(s).",
-                "description": "Force a new version of online metadata role(s). The new metadata version(s) will have extended expiration which will equal to: today + ROLE_NAME_EXPIRATION number of days, where ROLE_NAME_EXPIRATION is a tuf repository setting. Note: depending on which metadata role you want to update other online roles will likely be updated as well otherwise consistency will be lost.",
+                "description": "Force a new version of online metadata role(s). If the roles list is empty all roles will be updated. The new metadata version(s) will have extended expiration which will equal to: today + ROLE_NAME_EXPIRATION number of days, where ROLE_NAME_EXPIRATION is a tuf repository setting. Note: depending on which metadata role you want to update other online roles will likely be updated as well otherwise consistency will be lost.",
                 "operationId": "put_api_v1_metadata__put",
                 "requestBody": {
                     "content": {
@@ -1135,7 +1135,6 @@
                         "items": {
                             "type": "string",
                             "enum": [
-                                "root",
                                 "targets",
                                 "snapshot",
                                 "timestamp",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -143,49 +143,6 @@
             }
         },
         "/api/v1/metadata/": {
-            "put": {
-                "tags": [
-                    "Metadata"
-                ],
-                "summary": "Force a new version of online metadata role(s).",
-                "description": "Force a new version of online metadata role(s). If the roles list is empty all roles will be updated. The new metadata version(s) will have extended expiration which will equal to: today + ROLE_NAME_EXPIRATION number of days, where ROLE_NAME_EXPIRATION is a tuf repository setting. Note: depending on which metadata role you want to update other online roles will likely be updated as well otherwise consistency will be lost.",
-                "operationId": "put_api_v1_metadata__put",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/MetadataPutPayload"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "202": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/MetadataPutResponse"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Not found"
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
             "post": {
                 "tags": [
                     "Metadata"
@@ -210,6 +167,51 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/MetadataPostResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/metadata/online": {
+            "post": {
+                "tags": [
+                    "Metadata"
+                ],
+                "summary": "Force a new version of online metadata role(s).",
+                "description": "Force a new version of online metadata role(s). If the roles list is empty all roles will be updated. The new metadata version(s) will have extended expiration which will equal to: today + ROLE_NAME_EXPIRATION number of days, where ROLE_NAME_EXPIRATION is a tuf repository setting. Note: depending on which metadata role you want to update other online roles will likely be updated as well otherwise consistency will be lost.",
+                "operationId": "post_api_v1_metadata_online_post",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MetadataOnlinePostPayload"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "202": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MetadataOnlinePostResponse"
                                 }
                             }
                         }
@@ -850,31 +852,6 @@
                 ],
                 "title": "DelegatedRole"
             },
-            "DeleteData": {
-                "properties": {
-                    "task_id": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Task Id"
-                    },
-                    "last_update": {
-                        "type": "string",
-                        "format": "date-time",
-                        "title": "Last Update"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "last_update"
-                ],
-                "title": "DeleteData"
-            },
             "DeletePayload": {
                 "properties": {
                     "artifacts": {
@@ -994,6 +971,52 @@
                 "type": "object",
                 "title": "HTTPValidationError"
             },
+            "MetadataOnlinePostPayload": {
+                "properties": {
+                    "roles": {
+                        "items": {
+                            "type": "string",
+                            "enum": [
+                                "targets",
+                                "snapshot",
+                                "timestamp",
+                                "bins"
+                            ]
+                        },
+                        "type": "array",
+                        "title": "Roles"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "roles"
+                ],
+                "title": "MetadataOnlinePostPayload"
+            },
+            "MetadataOnlinePostResponse": {
+                "properties": {
+                    "data": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/repository_service_tuf_api__metadata__ResponseData"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "message": {
+                        "type": "string",
+                        "title": "Message"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "data",
+                    "message"
+                ],
+                "title": "MetadataOnlinePostResponse"
+            },
             "MetadataPostPayload": {
                 "properties": {
                     "metadata": {
@@ -1105,7 +1128,7 @@
                     "data": {
                         "anyOf": [
                             {
-                                "$ref": "#/components/schemas/PostData"
+                                "$ref": "#/components/schemas/repository_service_tuf_api__metadata__ResponseData"
                             },
                             {
                                 "type": "null"
@@ -1129,57 +1152,6 @@
                     }
                 }
             },
-            "MetadataPutPayload": {
-                "properties": {
-                    "roles": {
-                        "items": {
-                            "type": "string",
-                            "enum": [
-                                "targets",
-                                "snapshot",
-                                "timestamp",
-                                "bins"
-                            ]
-                        },
-                        "type": "array",
-                        "title": "Roles"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "roles"
-                ],
-                "title": "MetadataPutPayload",
-                "example": {
-                    "roles": [
-                        "targets",
-                        "snapshot"
-                    ]
-                }
-            },
-            "MetadataPutResponse": {
-                "properties": {
-                    "data": {
-                        "$ref": "#/components/schemas/TaskData"
-                    },
-                    "message": {
-                        "type": "string",
-                        "title": "Message"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "message"
-                ],
-                "title": "MetadataPutResponse",
-                "example": {
-                    "data": {
-                        "task_id": "7a634b556f784ae88785d36425f9a218",
-                        "last_update": "2022-12-01T12:10:00.578086"
-                    },
-                    "message": "Force new online metadata accepted."
-                }
-            },
             "MetadataSignDeletePayload": {
                 "properties": {
                     "role": {
@@ -1201,7 +1173,7 @@
                     "data": {
                         "anyOf": [
                             {
-                                "$ref": "#/components/schemas/DeleteData"
+                                "$ref": "#/components/schemas/repository_service_tuf_api__metadata__ResponseData"
                             },
                             {
                                 "type": "null"
@@ -1506,39 +1478,12 @@
                     "message": "Task state."
                 }
             },
-            "ResponseData": {
-                "properties": {
-                    "artifacts": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array",
-                        "title": "Artifacts"
-                    },
-                    "task_id": {
-                        "type": "string",
-                        "title": "Task Id"
-                    },
-                    "last_update": {
-                        "type": "string",
-                        "format": "date-time",
-                        "title": "Last Update"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "artifacts",
-                    "task_id",
-                    "last_update"
-                ],
-                "title": "ResponseData"
-            },
             "ResponsePostAdd": {
                 "properties": {
                     "data": {
                         "anyOf": [
                             {
-                                "$ref": "#/components/schemas/ResponseData"
+                                "$ref": "#/components/schemas/repository_service_tuf_api__artifacts__ResponseData"
                             },
                             {
                                 "type": "null"
@@ -1577,7 +1522,7 @@
                     "data": {
                         "anyOf": [
                             {
-                                "$ref": "#/components/schemas/ResponseData"
+                                "$ref": "#/components/schemas/repository_service_tuf_api__artifacts__ResponseData"
                             },
                             {
                                 "type": "null"
@@ -1616,7 +1561,7 @@
                     "data": {
                         "anyOf": [
                             {
-                                "$ref": "#/components/schemas/ResponseData"
+                                "$ref": "#/components/schemas/repository_service_tuf_api__artifacts__ResponseData"
                             },
                             {
                                 "type": "null"
@@ -2180,6 +2125,8 @@
                 "properties": {
                     "bit_length": {
                         "type": "integer",
+                        "exclusiveMaximum": 15.0,
+                        "exclusiveMinimum": 0.0,
                         "title": "Bit Length"
                     },
                     "name_prefix": {
@@ -2417,6 +2364,33 @@
                 ],
                 "title": "ValidationError"
             },
+            "repository_service_tuf_api__artifacts__ResponseData": {
+                "properties": {
+                    "artifacts": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "title": "Artifacts"
+                    },
+                    "task_id": {
+                        "type": "string",
+                        "title": "Task Id"
+                    },
+                    "last_update": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Last Update"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "artifacts",
+                    "task_id",
+                    "last_update"
+                ],
+                "title": "ResponseData"
+            },
             "repository_service_tuf_api__bootstrap__Settings": {
                 "properties": {
                     "roles": {
@@ -2444,6 +2418,31 @@
                     "expiration"
                 ],
                 "title": "Settings"
+            },
+            "repository_service_tuf_api__metadata__ResponseData": {
+                "properties": {
+                    "task_id": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Task Id"
+                    },
+                    "last_update": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Last Update"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "last_update"
+                ],
+                "title": "ResponseData"
             }
         }
     }

--- a/repository_service_tuf_api/api/metadata.py
+++ b/repository_service_tuf_api/api/metadata.py
@@ -31,6 +31,25 @@ def post(payload: metadata.MetadataPostPayload):
     return metadata.post_metadata(payload)
 
 
+@router.put(
+    "/",
+    summary="Force a new version of online metadata role(s).",
+    description=(
+        "Force a new version of online metadata role(s). The new metadata "
+        "version(s) will have extended expiration which will equal to: "
+        "today + ROLE_NAME_EXPIRATION number of days, where "
+        "ROLE_NAME_EXPIRATION is a tuf repository setting. Note: depending on "
+        "which metadata role you want to update other online roles will likely"
+        " be updated as well otherwise consistency will be lost."
+    ),
+    response_model=metadata.MetadataPutResponse,
+    response_model_exclude_none=True,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+def put(payload: metadata.MetadataPutPayload):
+    return metadata.put_metadata(payload)
+
+
 @router.get(
     "/sign",
     summary=(

--- a/repository_service_tuf_api/api/metadata.py
+++ b/repository_service_tuf_api/api/metadata.py
@@ -31,8 +31,8 @@ def post(payload: metadata.MetadataPostPayload):
     return metadata.post_metadata(payload)
 
 
-@router.put(
-    "/",
+@router.post(
+    "/online",
     summary="Force a new version of online metadata role(s).",
     description=(
         "Force a new version of online metadata role(s). If the roles list is "
@@ -43,12 +43,12 @@ def post(payload: metadata.MetadataPostPayload):
         "which metadata role you want to update other online roles will likely"
         " be updated as well otherwise consistency will be lost."
     ),
-    response_model=metadata.MetadataPutResponse,
+    response_model=metadata.MetadataOnlinePostResponse,
     response_model_exclude_none=True,
     status_code=status.HTTP_202_ACCEPTED,
 )
-def put(payload: metadata.MetadataPutPayload):
-    return metadata.put_metadata(payload)
+def post(payload: metadata.MetadataOnlinePostPayload):
+    return metadata.post_metadata_online(payload)
 
 
 @router.get(

--- a/repository_service_tuf_api/api/metadata.py
+++ b/repository_service_tuf_api/api/metadata.py
@@ -47,7 +47,7 @@ def post(payload: metadata.MetadataPostPayload):
     response_model_exclude_none=True,
     status_code=status.HTTP_202_ACCEPTED,
 )
-def post(payload: metadata.MetadataOnlinePostPayload):
+def post_online(payload: metadata.MetadataOnlinePostPayload):
     return metadata.post_metadata_online(payload)
 
 

--- a/repository_service_tuf_api/api/metadata.py
+++ b/repository_service_tuf_api/api/metadata.py
@@ -35,8 +35,9 @@ def post(payload: metadata.MetadataPostPayload):
     "/",
     summary="Force a new version of online metadata role(s).",
     description=(
-        "Force a new version of online metadata role(s). The new metadata "
-        "version(s) will have extended expiration which will equal to: "
+        "Force a new version of online metadata role(s). If the roles list is "
+        "empty all roles will be updated. The new metadata version(s) will "
+        "have extended expiration which will equal to: "
         "today + ROLE_NAME_EXPIRATION number of days, where "
         "ROLE_NAME_EXPIRATION is a tuf repository setting. Note: depending on "
         "which metadata role you want to update other online roles will likely"

--- a/repository_service_tuf_api/common_models.py
+++ b/repository_service_tuf_api/common_models.py
@@ -52,10 +52,7 @@ class TUFSignedDelegationsRoles(BaseModel):
 
 
 class TUFSignedDelegationsSuccinctRoles(BaseModel):
-    # We cannot add the limit range
-    # https://github.com/tiangolo/fastapi/discussions/9140
-    # bit_length: int = Field(gt=0, lt=15)
-    bit_length: int
+    bit_length: int = Field(gt=0, lt=15)
     name_prefix: str
     keyids: List[str]
     threshold: int

--- a/repository_service_tuf_api/common_models.py
+++ b/repository_service_tuf_api/common_models.py
@@ -42,8 +42,11 @@ class Roles(Enum):
         delegated_roles: List[str]= settings_repository.get_fresh(
             "DELEGATED_ROLES_NAMES"
         )
-        bins = all(r.startswith(Roles.BINS.value) for r in delegated_roles)
-        if bins:
+        # All delegated roles names should start with "bins" if we are using
+        # hash bin delegation and none of the delegated roles should start with
+        # "bins" if we are using custom target delegation.
+        bins_used = True if delegated_roles[0].startswith("bins") else False
+        if bins_used:
             online_roles.append(Roles.BINS.value)
         else:
             online_roles.extend(delegated_roles)

--- a/repository_service_tuf_api/common_models.py
+++ b/repository_service_tuf_api/common_models.py
@@ -8,6 +8,8 @@ from typing import Any, Dict, List, Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from repository_service_tuf_api import settings_repository
+
 
 class Roles(Enum):
     ROOT = "root"
@@ -19,6 +21,15 @@ class Roles(Enum):
     @staticmethod
     def values() -> List[str]:
         return Literal["root", "targets", "snapshot", "timestamp", "bins"]
+
+    @staticmethod
+    def online_roles_values() -> List[str]:
+        online_roles = Literal["targets", "snapshot", "timestamp", "bins"]
+        settings_repository.reload()
+        if not settings_repository.get_fresh("TARGETS_ONLINE_KEY", True):
+            online_roles = Literal["snapshot", "timestamp", "bins"]
+
+        return online_roles
 
 
 class BaseErrorResponse(BaseModel):

--- a/repository_service_tuf_api/common_models.py
+++ b/repository_service_tuf_api/common_models.py
@@ -35,10 +35,18 @@ class Roles(Enum):
 
     @staticmethod
     def online_roles_values() -> List[str]:
-        online_roles = Literal["targets", "snapshot", "timestamp", "bins"]
-        settings_repository.reload()
-        if not settings_repository.get_fresh("TARGETS_ONLINE_KEY", True):
-            online_roles = Literal["snapshot", "timestamp", "bins"]
+        online_roles: List[str] = ["snapshot", "timestamp"]
+        if settings_repository.get_fresh("TARGETS_ONLINE_KEY", True):
+            online_roles.append("targets")
+
+        delegated_roles: List[str]= settings_repository.get_fresh(
+            "DELEGATED_ROLES_NAMES"
+        )
+        bins = all(r.startswith(Roles.BINS.value) for r in delegated_roles)
+        if bins:
+            online_roles.append(Roles.BINS.value)
+        else:
+            online_roles.extend(delegated_roles)
 
         return online_roles
 

--- a/repository_service_tuf_api/common_models.py
+++ b/repository_service_tuf_api/common_models.py
@@ -39,7 +39,7 @@ class Roles(Enum):
         if settings_repository.get_fresh("TARGETS_ONLINE_KEY", True):
             online_roles.append("targets")
 
-        delegated_roles: List[str]= settings_repository.get_fresh(
+        delegated_roles: List[str] = settings_repository.get_fresh(
             "DELEGATED_ROLES_NAMES"
         )
         # All delegated roles names should start with "bins" if we are using

--- a/repository_service_tuf_api/common_models.py
+++ b/repository_service_tuf_api/common_models.py
@@ -19,6 +19,17 @@ class Roles(Enum):
     BINS = "bins"
 
     @staticmethod
+    def is_role(input: Any) -> bool:
+        if not isinstance(input, str):
+            return False
+
+        return any(input == role.value for role in Roles)
+
+    @staticmethod
+    def all_str() -> str:
+        return "root, targets, snapshot, timestamp and bins"
+
+    @staticmethod
     def values() -> List[str]:
         return Literal["root", "targets", "snapshot", "timestamp", "bins"]
 

--- a/repository_service_tuf_api/config.py
+++ b/repository_service_tuf_api/config.py
@@ -16,6 +16,7 @@ from repository_service_tuf_api import (
     repository_metadata,
     settings_repository,
 )
+from repository_service_tuf_api.common_models import Roles
 
 
 class PutData(BaseModel):
@@ -42,7 +43,7 @@ class PutResponse(BaseModel):
 
 class Settings(BaseModel):
     # Only online roles can be dict keys
-    expiration: Dict[str, int]
+    expiration: Dict[Roles.online_roles_values(), int]
 
 
 with open("tests/data_examples/config/update_settings.json") as f:

--- a/repository_service_tuf_api/config.py
+++ b/repository_service_tuf_api/config.py
@@ -16,7 +16,6 @@ from repository_service_tuf_api import (
     repository_metadata,
     settings_repository,
 )
-from repository_service_tuf_api.common_models import Roles
 
 
 class PutData(BaseModel):
@@ -43,7 +42,7 @@ class PutResponse(BaseModel):
 
 class Settings(BaseModel):
     # Only online roles can be dict keys
-    expiration: Dict[Roles.online_roles_values(), int]
+    expiration: Dict[str, int]
 
 
 with open("tests/data_examples/config/update_settings.json") as f:

--- a/repository_service_tuf_api/metadata.py
+++ b/repository_service_tuf_api/metadata.py
@@ -128,7 +128,8 @@ def post_metadata_online(
             },
         )
 
-    targets_in = "targets" in payload.roles
+    roles = payload.roles
+    targets_in = "targets" in roles
     settings_repository.reload()
     targets_online = settings_repository.get_fresh("TARGETS_ONLINE_KEY", True)
     if targets_in and not targets_online:
@@ -146,7 +147,7 @@ def post_metadata_online(
     bins_used = all(r.startswith(Roles.BINS.value) for r in delegated_roles)
     if bins_used:
         # This indicates succinct hash bins are used
-        if any(not Roles.is_role(role) for role in payload.roles):
+        if len(roles) > 0 and any(not Roles.is_role(role) for role in roles):
             raise HTTPException(
                 status.HTTP_200_OK,
                 detail={
@@ -158,7 +159,7 @@ def post_metadata_online(
                 },
             )
     else:
-        if Roles.BINS.value in payload.roles:
+        if Roles.BINS.value in roles:
             raise HTTPException(
                 status.HTTP_200_OK,
                 detail={
@@ -169,7 +170,6 @@ def post_metadata_online(
                     ),
                 },
             )
-
 
     # If no roles are provided, then bump all.
     if len(payload.roles) == 0:

--- a/repository_service_tuf_api/metadata.py
+++ b/repository_service_tuf_api/metadata.py
@@ -5,7 +5,7 @@
 
 import json
 from datetime import datetime, timezone
-from typing import Dict, Literal
+from typing import Dict, Literal, List
 
 from fastapi import HTTPException, status
 from pydantic import BaseModel, ConfigDict

--- a/repository_service_tuf_api/metadata.py
+++ b/repository_service_tuf_api/metadata.py
@@ -126,6 +126,18 @@ def put_metadata(payload: MetadataPutPayload) -> MetadataPutResponse:
             },
         )
 
+    settings_repository.reload()
+    if not settings_repository.get_fresh("TARGETS_ONLINE_KEY"):
+        raise HTTPException(
+            status.HTTP_200_OK,
+            detail={
+                "message": "Task not accepted.",
+                "error": (
+                    "Targets is an offline role - use other endpoint to update"
+                ),
+            },
+        )
+
     task_id = get_task_id()
     repository_metadata.apply_async(
         kwargs={

--- a/repository_service_tuf_api/metadata.py
+++ b/repository_service_tuf_api/metadata.py
@@ -157,6 +157,19 @@ def post_metadata_online(
                     ),
                 },
             )
+    else:
+        if Roles.BINS.value in payload.roles:
+            raise HTTPException(
+                status.HTTP_200_OK,
+                detail={
+                    "message": "Task not accepted.",
+                    "error": (
+                        "Custom target delegation used and "
+                        "bins cannot be bumped"
+                    ),
+                },
+            )
+
 
     # If no roles are provided, then bump all.
     if len(payload.roles) == 0:

--- a/repository_service_tuf_api/metadata.py
+++ b/repository_service_tuf_api/metadata.py
@@ -89,7 +89,7 @@ def post_metadata(payload: MetadataPostPayload) -> MetadataPostResponse:
     return MetadataPostResponse(data=data, message=message)
 
 
-class MetadataPutPayload(BaseModel):
+class MetadataOnlinePostPayload(BaseModel):
     roles: List[Roles.online_roles_values()]
 
     class Config:
@@ -98,7 +98,7 @@ class MetadataPutPayload(BaseModel):
         schema_extra = {"example": example}
 
 
-class MetadataPutResponse(BaseModel):
+class MetadataOnlinePostResponse(BaseModel):
     data: Optional[ResponseData]
     message: str
 
@@ -114,7 +114,9 @@ class MetadataPutResponse(BaseModel):
         schema_extra = {"example": example}
 
 
-def put_metadata(payload: MetadataPutPayload) -> MetadataPutResponse:
+def post_metadata_online(
+    payload: MetadataOnlinePostPayload
+) -> MetadataOnlinePostResponse:
     bs_state = bootstrap_state()
     if bs_state.bootstrap is False:
         raise HTTPException(
@@ -159,7 +161,7 @@ def put_metadata(payload: MetadataPutPayload) -> MetadataPutResponse:
         "task_id": task_id,
         "last_update": datetime.now(),
     }
-    return MetadataPutResponse(data=data, message=message)
+    return MetadataOnlinePostResponse(data=data, message=message)
 
 
 class RolesData(BaseModel):

--- a/repository_service_tuf_api/metadata.py
+++ b/repository_service_tuf_api/metadata.py
@@ -89,7 +89,7 @@ def post_metadata(payload: MetadataPostPayload) -> MetadataPostResponse:
 
 
 class MetadataPutPayload(BaseModel):
-    roles: List[Roles.values()]
+    roles: List[Roles.online_roles_values()]
 
     class Config:
         example = {"roles": ["targets", "snapshot"]}

--- a/repository_service_tuf_api/metadata.py
+++ b/repository_service_tuf_api/metadata.py
@@ -9,6 +9,7 @@ from typing import Dict, List, Literal
 
 from fastapi import HTTPException, status
 from pydantic import BaseModel, ConfigDict
+from typing import List, Optional
 
 from repository_service_tuf_api import (
     bootstrap_state,
@@ -35,7 +36,7 @@ class MetadataPostPayload(BaseModel):
     metadata: Dict[Literal[Roles.ROOT.value], TUFMetadata]
 
 
-class PostData(BaseModel):
+class ResponseData(BaseModel):
     task_id: str | None = None
     last_update: datetime
 
@@ -51,7 +52,7 @@ class MetadataPostResponse(BaseModel):
             }
         }
     )
-    data: PostData | None = None
+    data: ResponseData | None = None
     message: str
 
 
@@ -98,7 +99,7 @@ class MetadataPutPayload(BaseModel):
 
 
 class MetadataPutResponse(BaseModel):
-    data: Optional[TaskData]
+    data: Optional[ResponseData]
     message: str
 
     class Config:
@@ -234,7 +235,7 @@ class MetadataSignPostResponse(BaseModel):
             }
         }
     )
-    data: PostData | None = None
+    data: ResponseData | None = None
     message: str
 
 
@@ -308,11 +309,6 @@ class MetadataSignDeletePayload(BaseModel):
     role: str
 
 
-class DeleteData(BaseModel):
-    task_id: str | None = None
-    last_update: datetime
-
-
 class MetadataSignDeleteResponse(BaseModel):
     model_config = ConfigDict(
         json_schema_extra={
@@ -325,7 +321,7 @@ class MetadataSignDeleteResponse(BaseModel):
             }
         }
     )
-    data: DeleteData | None = None
+    data: ResponseData | None = None
     message: str
 
 

--- a/repository_service_tuf_api/metadata.py
+++ b/repository_service_tuf_api/metadata.py
@@ -128,8 +128,9 @@ def post_metadata_online(
             },
         )
 
+    targets_in = "targets" in payload
     settings_repository.reload()
-    if not settings_repository.get_fresh("TARGETS_ONLINE_KEY"):
+    if targets_in and not settings_repository.get_fresh("TARGETS_ONLINE_KEY"):
         raise HTTPException(
             status.HTTP_200_OK,
             detail={

--- a/repository_service_tuf_api/metadata.py
+++ b/repository_service_tuf_api/metadata.py
@@ -5,7 +5,7 @@
 
 import json
 from datetime import datetime, timezone
-from typing import Dict, Literal, List
+from typing import Dict, List, Literal
 
 from fastapi import HTTPException, status
 from pydantic import BaseModel, ConfigDict

--- a/repository_service_tuf_api/metadata.py
+++ b/repository_service_tuf_api/metadata.py
@@ -138,6 +138,10 @@ def put_metadata(payload: MetadataPutPayload) -> MetadataPutResponse:
             },
         )
 
+    # If no roles are provided, then bump all.
+    if len(payload.roles) == 0:
+        payload.roles = Roles.online_roles_values()
+
     task_id = get_task_id()
     repository_metadata.apply_async(
         kwargs={

--- a/repository_service_tuf_api/metadata.py
+++ b/repository_service_tuf_api/metadata.py
@@ -92,26 +92,28 @@ def post_metadata(payload: MetadataPostPayload) -> MetadataPostResponse:
 class MetadataOnlinePostPayload(BaseModel):
     roles: List[Roles.online_roles_values()]
 
-    class Config:
-        example = {"roles": ["targets", "snapshot"]}
-
-        schema_extra = {"example": example}
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {"roles": ["targets", "snapshot"]}
+        }
+    )
 
 
 class MetadataOnlinePostResponse(BaseModel):
     data: Optional[ResponseData]
     message: str
 
-    class Config:
-        example = {
-            "data": {
-                "task_id": "7a634b556f784ae88785d36425f9a218",
-                "last_update": "2022-12-01T12:10:00.578086",
-            },
-            "message": "Force new online metadata accepted.",
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "data": {
+                    "task_id": "7a634b556f784ae88785d36425f9a218",
+                    "last_update": "2022-12-01T12:10:00.578086",
+                },
+                "message": "Force new online metadata accepted.",
+            }
         }
-
-        schema_extra = {"example": example}
+    )
 
 
 def post_metadata_online(

--- a/tests/unit/api/test_common_models.py
+++ b/tests/unit/api/test_common_models.py
@@ -1,5 +1,3 @@
-from typing import Literal
-
 import pretend
 
 from repository_service_tuf_api import common_models
@@ -28,7 +26,7 @@ class TestRoles:
         assert result == ["snapshot", "timestamp", "targets", "bins"]
         assert mocked_settings_repository.get_fresh.calls == [
             pretend.call("TARGETS_ONLINE_KEY", True),
-            pretend.call("DELEGATED_ROLES_NAMES")
+            pretend.call("DELEGATED_ROLES_NAMES"),
         ]
 
     def test_online_values_custom_delegations(self, monkeypatch):
@@ -51,7 +49,7 @@ class TestRoles:
         assert result == ["snapshot", "timestamp", "targets", "foo", "bar"]
         assert mocked_settings_repository.get_fresh.calls == [
             pretend.call("TARGETS_ONLINE_KEY", True),
-            pretend.call("DELEGATED_ROLES_NAMES")
+            pretend.call("DELEGATED_ROLES_NAMES"),
         ]
 
     def test_getting_online_values_targets_role_is_offline(self, monkeypatch):
@@ -74,7 +72,7 @@ class TestRoles:
         assert result == ["snapshot", "timestamp", "bins"]
         assert mocked_settings_repository.get_fresh.calls == [
             pretend.call("TARGETS_ONLINE_KEY", True),
-            pretend.call("DELEGATED_ROLES_NAMES")
+            pretend.call("DELEGATED_ROLES_NAMES"),
         ]
 
     def test_is_role_true_all_roles(self):

--- a/tests/unit/api/test_common_models.py
+++ b/tests/unit/api/test_common_models.py
@@ -41,3 +41,18 @@ class TestRoles:
         assert mocked_settings_repository.get_fresh.calls == [
             pretend.call("TARGETS_ONLINE_KEY", True)
         ]
+
+    def test_is_role_true_all_roles(self):
+        all = ["root", "targets", "snapshot", "timestamp", "bins"]
+        for role in all:
+            assert common_models.Roles.is_role(role) is True
+
+    def test_is_role_false_str(self):
+        all_roles = ["root1", "1root", "root.json", "f", "bin", "bin0", ""]
+        for role in all_roles:
+            assert common_models.Roles.is_role(role) is False
+
+    def test_is_role_false_other_input(self):
+        all_roles = [1, None, True, [], {}]
+        for role in all_roles:
+            assert common_models.Roles.is_role(role) is False

--- a/tests/unit/api/test_common_models.py
+++ b/tests/unit/api/test_common_models.py
@@ -1,0 +1,43 @@
+from typing import Literal
+
+import pretend
+
+from repository_service_tuf_api import common_models
+
+COMMON_MODELS_PATH = "repository_service_tuf_api.common_models"
+
+
+class TestRoles:
+    def test_getting_online_values(self, monkeypatch):
+        mocked_settings_repository = pretend.stub(
+            reload=pretend.call_recorder(lambda: None),
+            get_fresh=pretend.call_recorder(lambda *a: True),
+        )
+        monkeypatch.setattr(
+            f"{COMMON_MODELS_PATH}.settings_repository",
+            mocked_settings_repository,
+        )
+
+        result = common_models.Roles.online_roles_values()
+        assert result == Literal["targets", "snapshot", "timestamp", "bins"]
+        assert mocked_settings_repository.reload.calls == [pretend.call()]
+        assert mocked_settings_repository.get_fresh.calls == [
+            pretend.call("TARGETS_ONLINE_KEY", True)
+        ]
+
+    def test_getting_online_values_targets_role_is_offline(self, monkeypatch):
+        mocked_settings_repository = pretend.stub(
+            reload=pretend.call_recorder(lambda: None),
+            get_fresh=pretend.call_recorder(lambda *a: False),
+        )
+        monkeypatch.setattr(
+            f"{COMMON_MODELS_PATH}.settings_repository",
+            mocked_settings_repository,
+        )
+
+        result = common_models.Roles.online_roles_values()
+        assert result == Literal["snapshot", "timestamp", "bins"]
+        assert mocked_settings_repository.reload.calls == [pretend.call()]
+        assert mocked_settings_repository.get_fresh.calls == [
+            pretend.call("TARGETS_ONLINE_KEY", True)
+        ]

--- a/tests/unit/api/test_metadata.py
+++ b/tests/unit/api/test_metadata.py
@@ -13,6 +13,7 @@ from fastapi import status
 import repository_service_tuf_api.common_models as common_models
 
 METADATA_URL = "/api/v1/metadata/"
+METADATA_ONLINE_URL = "/api/v1/metadata/online"
 SIGN_URL = "/api/v1/metadata/sign/"
 DELETE_SIGN_URL = "/api/v1/metadata/sign/delete"
 MOCK_PATH = "repository_service_tuf_api.metadata"
@@ -154,8 +155,8 @@ class TestPostMetadata:
         } == response.json()
 
 
-class TestPutMetadata:
-    def test_put_metadata(self, test_client, monkeypatch):
+class TestPostMetadataOnline:
+    def test_post_metadata_online(self, test_client, monkeypatch):
         mocked_bootstrap_state = pretend.call_recorder(
             lambda: pretend.stub(bootstrap=True, state="ab123")
         )
@@ -193,7 +194,7 @@ class TestPutMetadata:
         )
         payload = {"roles": ["snapshot", "targets"]}
 
-        response = test_client.put(METADATA_URL, json=payload)
+        response = test_client.post(METADATA_ONLINE_URL, json=payload)
         assert response.status_code == status.HTTP_202_ACCEPTED, response.text
         assert response.json() == {
             "data": {
@@ -221,7 +222,9 @@ class TestPutMetadata:
         ]
         assert fake_datetime.now.calls == [pretend.call()]
 
-    def test_put_metadata_empty_payload(self, test_client, monkeypatch):
+    def test_post_metadata_online_empty_payload(
+        self, test_client, monkeypatch
+    ):
         mocked_bootstrap_state = pretend.call_recorder(
             lambda: pretend.stub(bootstrap=True, state="ab123")
         )
@@ -259,7 +262,7 @@ class TestPutMetadata:
         )
         payload = {"roles": []}
 
-        response = test_client.put(METADATA_URL, json=payload)
+        response = test_client.post(METADATA_ONLINE_URL, json=payload)
         assert response.status_code == status.HTTP_202_ACCEPTED, response.text
         assert response.json() == {
             "data": {
@@ -288,7 +291,9 @@ class TestPutMetadata:
         ]
         assert fake_datetime.now.calls == [pretend.call()]
 
-    def test_put_metadata_bootstrap_not_ready(self, test_client, monkeypatch):
+    def test_post_metadata_online_bootstrap_not_ready(
+        self, test_client, monkeypatch
+    ):
         mocked_bootstrap_state = pretend.call_recorder(
             lambda: pretend.stub(bootstrap=False, state="signing-")
         )
@@ -298,7 +303,7 @@ class TestPutMetadata:
             mocked_bootstrap_state,
         )
 
-        response = test_client.put(METADATA_URL, json=payload)
+        response = test_client.post(METADATA_ONLINE_URL, json=payload)
         assert response.status_code == status.HTTP_200_OK, response.text
         assert response.json() == {
             "detail": {
@@ -308,7 +313,7 @@ class TestPutMetadata:
         }
         assert mocked_bootstrap_state.calls == [pretend.call()]
 
-    def test_put_metadata_targets_offline_role_cannot_update(
+    def test_post_metadata_online_targets_offline_role_cannot_update(
         self, test_client, monkeypatch
     ):
         mocked_bootstrap_state = pretend.call_recorder(
@@ -328,7 +333,7 @@ class TestPutMetadata:
         )
         payload = {"roles": ["snapshot", "targets"]}
 
-        response = test_client.put(METADATA_URL, json=payload)
+        response = test_client.post(METADATA_ONLINE_URL, json=payload)
         assert response.status_code == status.HTTP_200_OK, response.text
         err_msg = "Targets is an offline role - use other endpoint to update"
         assert response.json() == {

--- a/tests/unit/api/test_metadata.py
+++ b/tests/unit/api/test_metadata.py
@@ -264,9 +264,7 @@ class TestPostMetadataOnline:
             online_roles_values=pretend.call_recorder(
                 lambda: fake_online_roles_return
             ),
-            BINS=pretend.stub(
-                value="bins"
-            )
+            BINS=pretend.stub(value="bins"),
         )
         monkeypatch.setattr(
             "repository_service_tuf_api.metadata.Roles", fake_roles
@@ -309,7 +307,6 @@ class TestPostMetadataOnline:
         assert mocked_settings_repository.get_fresh.calls == [
             pretend.call("TARGETS_ONLINE_KEY", True),
             pretend.call("DELEGATED_ROLES_NAMES"),
-
         ]
         assert fake_roles.online_roles_values.calls == [pretend.call()]
         assert fake_get_task_id.calls == [pretend.call()]
@@ -463,9 +460,7 @@ class TestPostMetadataOnline:
 
         response = test_client.post(METADATA_ONLINE_URL, json=payload)
         assert response.status_code == status.HTTP_200_OK, response.text
-        err_msg = (
-            "Custom target delegation used and bins cannot be bumped"
-        )
+        err_msg = "Custom target delegation used and bins cannot be bumped"
         assert response.json() == {
             "detail": {
                 "message": "Task not accepted.",

--- a/tests/unit/api/test_metadata.py
+++ b/tests/unit/api/test_metadata.py
@@ -161,8 +161,7 @@ class TestPostMetadataOnline:
             lambda: pretend.stub(bootstrap=True, state="ab123")
         )
         monkeypatch.setattr(
-            "repository_service_tuf_api.metadata.bootstrap_state",
-            mocked_bootstrap_state,
+            f"{MOCK_PATH}.bootstrap_state", mocked_bootstrap_state
         )
 
         def fake_get_fresh(attr: str) -> bool:
@@ -177,29 +176,25 @@ class TestPostMetadataOnline:
             get_fresh=pretend.call_recorder(lambda *a: fake_get_fresh(a)),
         )
         monkeypatch.setattr(
-            "repository_service_tuf_api.metadata.settings_repository",
-            mocked_settings_repository,
+            f"{MOCK_PATH}.settings_repository", mocked_settings_repository
         )
         fake_id = "fake_id"
         fake_get_task_id = pretend.call_recorder(lambda: fake_id)
         monkeypatch.setattr(
-            "repository_service_tuf_api.metadata.get_task_id",
+            f"{MOCK_PATH}.get_task_id",
             fake_get_task_id,
         )
         fake_repository_metadata = pretend.stub(
             apply_async=pretend.call_recorder(lambda *a, **kw: None)
         )
         monkeypatch.setattr(
-            "repository_service_tuf_api.metadata.repository_metadata",
-            fake_repository_metadata,
+            f"{MOCK_PATH}.repository_metadata", fake_repository_metadata
         )
         fake_time = datetime(2019, 6, 16, 9, 5, 1)
         fake_datetime = pretend.stub(
             now=pretend.call_recorder(lambda: fake_time)
         )
-        monkeypatch.setattr(
-            "repository_service_tuf_api.metadata.datetime", fake_datetime
-        )
+        monkeypatch.setattr(f"{MOCK_PATH}.datetime", fake_datetime)
         payload = {"roles": ["snapshot", "targets"]}
 
         response = test_client.post(METADATA_ONLINE_URL, json=payload)
@@ -240,8 +235,7 @@ class TestPostMetadataOnline:
             lambda: pretend.stub(bootstrap=True, state="ab123")
         )
         monkeypatch.setattr(
-            "repository_service_tuf_api.metadata.bootstrap_state",
-            mocked_bootstrap_state,
+            f"{MOCK_PATH}.bootstrap_state", mocked_bootstrap_state
         )
 
         def fake_get_fresh(attr: str) -> bool:
@@ -256,8 +250,7 @@ class TestPostMetadataOnline:
             get_fresh=pretend.call_recorder(lambda *a: fake_get_fresh(a)),
         )
         monkeypatch.setattr(
-            "repository_service_tuf_api.metadata.settings_repository",
-            mocked_settings_repository,
+            f"{MOCK_PATH}.settings_repository", mocked_settings_repository
         )
         fake_online_roles_return = ["snapshot", "targets", "timestamp", "bins"]
         fake_roles = pretend.stub(
@@ -266,29 +259,21 @@ class TestPostMetadataOnline:
             ),
             BINS=pretend.stub(value="bins"),
         )
-        monkeypatch.setattr(
-            "repository_service_tuf_api.metadata.Roles", fake_roles
-        )
+        monkeypatch.setattr(f"{MOCK_PATH}.Roles", fake_roles)
         fake_id = "fake_id"
         fake_get_task_id = pretend.call_recorder(lambda: fake_id)
-        monkeypatch.setattr(
-            "repository_service_tuf_api.metadata.get_task_id",
-            fake_get_task_id,
-        )
+        monkeypatch.setattr(f"{MOCK_PATH}.get_task_id", fake_get_task_id)
         fake_repository_metadata = pretend.stub(
             apply_async=pretend.call_recorder(lambda *a, **kw: None)
         )
         monkeypatch.setattr(
-            "repository_service_tuf_api.metadata.repository_metadata",
-            fake_repository_metadata,
+            f"{MOCK_PATH}.repository_metadata", fake_repository_metadata
         )
         fake_time = datetime(2019, 6, 16, 9, 5, 1)
         fake_datetime = pretend.stub(
             now=pretend.call_recorder(lambda: fake_time)
         )
-        monkeypatch.setattr(
-            "repository_service_tuf_api.metadata.datetime", fake_datetime
-        )
+        monkeypatch.setattr(f"{MOCK_PATH}.datetime", fake_datetime)
         payload = {"roles": []}
 
         response = test_client.post(METADATA_ONLINE_URL, json=payload)
@@ -332,8 +317,7 @@ class TestPostMetadataOnline:
         )
         payload = {"roles": ["snapshot", "targets"]}
         monkeypatch.setattr(
-            "repository_service_tuf_api.metadata.bootstrap_state",
-            mocked_bootstrap_state,
+            f"{MOCK_PATH}.bootstrap_state", mocked_bootstrap_state
         )
 
         response = test_client.post(METADATA_ONLINE_URL, json=payload)
@@ -353,16 +337,14 @@ class TestPostMetadataOnline:
             lambda: pretend.stub(bootstrap=True, state="ab123")
         )
         monkeypatch.setattr(
-            "repository_service_tuf_api.metadata.bootstrap_state",
-            mocked_bootstrap_state,
+            f"{MOCK_PATH}.bootstrap_state", mocked_bootstrap_state
         )
         mocked_settings_repository = pretend.stub(
             reload=pretend.call_recorder(lambda: None),
             get_fresh=pretend.call_recorder(lambda *a: False),
         )
         monkeypatch.setattr(
-            "repository_service_tuf_api.metadata.settings_repository",
-            mocked_settings_repository,
+            f"{MOCK_PATH}.settings_repository", mocked_settings_repository
         )
         payload = {"roles": ["snapshot", "targets"]}
 
@@ -388,8 +370,7 @@ class TestPostMetadataOnline:
             lambda: pretend.stub(bootstrap=True, state="ab123")
         )
         monkeypatch.setattr(
-            "repository_service_tuf_api.metadata.bootstrap_state",
-            mocked_bootstrap_state,
+            f"{MOCK_PATH}.bootstrap_state", mocked_bootstrap_state
         )
 
         def fake_get_fresh(attr: str) -> bool:
@@ -404,8 +385,7 @@ class TestPostMetadataOnline:
             get_fresh=pretend.call_recorder(lambda *a: fake_get_fresh(a)),
         )
         monkeypatch.setattr(
-            "repository_service_tuf_api.metadata.settings_repository",
-            mocked_settings_repository,
+            f"{MOCK_PATH}.settings_repository", mocked_settings_repository
         )
         payload = {"roles": ["snapshot", "targets", "abcsdaw"]}
 
@@ -437,8 +417,7 @@ class TestPostMetadataOnline:
             lambda: pretend.stub(bootstrap=True, state="ab123")
         )
         monkeypatch.setattr(
-            "repository_service_tuf_api.metadata.bootstrap_state",
-            mocked_bootstrap_state,
+            f"{MOCK_PATH}.bootstrap_state", mocked_bootstrap_state
         )
 
         def fake_get_fresh(attr: str) -> bool:
@@ -453,8 +432,7 @@ class TestPostMetadataOnline:
             get_fresh=pretend.call_recorder(lambda *a: fake_get_fresh(a)),
         )
         monkeypatch.setattr(
-            "repository_service_tuf_api.metadata.settings_repository",
-            mocked_settings_repository,
+            f"{MOCK_PATH}.settings_repository", mocked_settings_repository
         )
         payload = {"roles": ["snapshot", "targets", "bins"]}
 

--- a/tests/unit/api/test_metadata.py
+++ b/tests/unit/api/test_metadata.py
@@ -5,7 +5,7 @@
 
 import copy
 import json
-from datetime import timezone
+from datetime import datetime, timezone
 
 import pretend
 from fastapi import status
@@ -192,7 +192,7 @@ class TestPostMetadataOnline:
             "repository_service_tuf_api.metadata.repository_metadata",
             fake_repository_metadata,
         )
-        fake_time = datetime.datetime(2019, 6, 16, 9, 5, 1)
+        fake_time = datetime(2019, 6, 16, 9, 5, 1)
         fake_datetime = pretend.stub(
             now=pretend.call_recorder(lambda: fake_time)
         )
@@ -271,7 +271,7 @@ class TestPostMetadataOnline:
             "repository_service_tuf_api.metadata.repository_metadata",
             fake_repository_metadata,
         )
-        fake_time = datetime.datetime(2019, 6, 16, 9, 5, 1)
+        fake_time = datetime(2019, 6, 16, 9, 5, 1)
         fake_datetime = pretend.stub(
             now=pretend.call_recorder(lambda: fake_time)
         )

--- a/tests/unit/api/test_metadata.py
+++ b/tests/unit/api/test_metadata.py
@@ -259,6 +259,18 @@ class TestPostMetadataOnline:
             "repository_service_tuf_api.metadata.settings_repository",
             mocked_settings_repository,
         )
+        fake_online_roles_return = ["snapshot", "targets", "timestamp", "bins"]
+        fake_roles = pretend.stub(
+            online_roles_values=pretend.call_recorder(
+                lambda: fake_online_roles_return
+            ),
+            BINS=pretend.stub(
+                value="bins"
+            )
+        )
+        monkeypatch.setattr(
+            "repository_service_tuf_api.metadata.Roles", fake_roles
+        )
         fake_id = "fake_id"
         fake_get_task_id = pretend.call_recorder(lambda: fake_id)
         monkeypatch.setattr(
@@ -297,9 +309,11 @@ class TestPostMetadataOnline:
         assert mocked_settings_repository.get_fresh.calls == [
             pretend.call("TARGETS_ONLINE_KEY", True),
             pretend.call("DELEGATED_ROLES_NAMES"),
+
         ]
+        assert fake_roles.online_roles_values.calls == [pretend.call()]
         assert fake_get_task_id.calls == [pretend.call()]
-        expected_payload = {"roles": common_models.Roles.online_roles_values()}
+        expected_payload = {"roles": fake_online_roles_return}
         assert fake_repository_metadata.apply_async.calls == [
             pretend.call(
                 kwargs={

--- a/tests/unit/api/test_metadata.py
+++ b/tests/unit/api/test_metadata.py
@@ -165,15 +165,16 @@ class TestPostMetadataOnline:
             mocked_bootstrap_state,
         )
 
-        def fake_get_fresh(setting: str) -> bool:
+        def fake_get_fresh(attr: str) -> bool:
+            setting = attr[0]
             if setting == "TARGETS_ONLINE_KEY":
                 return True
-            elif setting == "NUMBER_OF_DELEGATED_BINS":
-                return False
+            elif setting == "DELEGATED_ROLES_NAMES":
+                return ["bins-0", "bins-1"]
 
         mocked_settings_repository = pretend.stub(
             reload=pretend.call_recorder(lambda: None),
-            get_fresh=pretend.call_recorder(lambda a: fake_get_fresh(a)),
+            get_fresh=pretend.call_recorder(lambda *a: fake_get_fresh(a)),
         )
         monkeypatch.setattr(
             "repository_service_tuf_api.metadata.settings_repository",
@@ -213,11 +214,10 @@ class TestPostMetadataOnline:
         assert mocked_bootstrap_state.calls == [pretend.call()]
         assert mocked_settings_repository.reload.calls == [
             pretend.call(),
-            pretend.call(),
         ]
         assert mocked_settings_repository.get_fresh.calls == [
-            pretend.call("TARGETS_ONLINE_KEY"),
-            pretend.call("NUMBER_OF_DELEGATED_BINS"),
+            pretend.call("TARGETS_ONLINE_KEY", True),
+            pretend.call("DELEGATED_ROLES_NAMES"),
         ]
         assert fake_get_task_id.calls == [pretend.call()]
         assert fake_repository_metadata.apply_async.calls == [
@@ -244,15 +244,16 @@ class TestPostMetadataOnline:
             mocked_bootstrap_state,
         )
 
-        def fake_get_fresh(setting: str) -> bool:
+        def fake_get_fresh(attr: str) -> bool:
+            setting = attr[0]
             if setting == "TARGETS_ONLINE_KEY":
                 return True
-            elif setting == "NUMBER_OF_DELEGATED_BINS":
-                return False
+            elif setting == "DELEGATED_ROLES_NAMES":
+                return ["bins-0", "bins-1"]
 
         mocked_settings_repository = pretend.stub(
             reload=pretend.call_recorder(lambda: None),
-            get_fresh=pretend.call_recorder(lambda a: fake_get_fresh(a)),
+            get_fresh=pretend.call_recorder(lambda *a: fake_get_fresh(a)),
         )
         monkeypatch.setattr(
             "repository_service_tuf_api.metadata.settings_repository",
@@ -292,11 +293,10 @@ class TestPostMetadataOnline:
         assert mocked_bootstrap_state.calls == [pretend.call()]
         assert mocked_settings_repository.reload.calls == [
             pretend.call(),
-            pretend.call(),
         ]
         assert mocked_settings_repository.get_fresh.calls == [
-            pretend.call("TARGETS_ONLINE_KEY"),
-            pretend.call("NUMBER_OF_DELEGATED_BINS"),
+            pretend.call("TARGETS_ONLINE_KEY", True),
+            pretend.call("DELEGATED_ROLES_NAMES"),
         ]
         assert fake_get_task_id.calls == [pretend.call()]
         expected_payload = {"roles": common_models.Roles.online_roles_values()}
@@ -347,7 +347,7 @@ class TestPostMetadataOnline:
         )
         mocked_settings_repository = pretend.stub(
             reload=pretend.call_recorder(lambda: None),
-            get_fresh=pretend.call_recorder(lambda a: False),
+            get_fresh=pretend.call_recorder(lambda *a: False),
         )
         monkeypatch.setattr(
             "repository_service_tuf_api.metadata.settings_repository",
@@ -367,7 +367,7 @@ class TestPostMetadataOnline:
         assert mocked_bootstrap_state.calls == [pretend.call()]
         assert mocked_settings_repository.reload.calls == [pretend.call()]
         assert mocked_settings_repository.get_fresh.calls == [
-            pretend.call("TARGETS_ONLINE_KEY")
+            pretend.call("TARGETS_ONLINE_KEY", True)
         ]
 
     def test_post_metadata_online_bins_used_bad_payload(
@@ -380,9 +380,17 @@ class TestPostMetadataOnline:
             "repository_service_tuf_api.metadata.bootstrap_state",
             mocked_bootstrap_state,
         )
+
+        def fake_get_fresh(attr: str) -> bool:
+            setting = attr[0]
+            if setting == "TARGETS_ONLINE_KEY":
+                return True
+            elif setting == "DELEGATED_ROLES_NAMES":
+                return ["bins-0", "bins-1"]
+
         mocked_settings_repository = pretend.stub(
             reload=pretend.call_recorder(lambda: None),
-            get_fresh=pretend.call_recorder(lambda a: True),
+            get_fresh=pretend.call_recorder(lambda *a: fake_get_fresh(a)),
         )
         monkeypatch.setattr(
             "repository_service_tuf_api.metadata.settings_repository",
@@ -405,11 +413,10 @@ class TestPostMetadataOnline:
         assert mocked_bootstrap_state.calls == [pretend.call()]
         assert mocked_settings_repository.reload.calls == [
             pretend.call(),
-            pretend.call(),
         ]
         assert mocked_settings_repository.get_fresh.calls == [
-            pretend.call("TARGETS_ONLINE_KEY"),
-            pretend.call("NUMBER_OF_DELEGATED_BINS"),
+            pretend.call("TARGETS_ONLINE_KEY", True),
+            pretend.call("DELEGATED_ROLES_NAMES"),
         ]
 
 


### PR DESCRIPTION
# Description
<!--- What is the PR about? -->

Add support for `PUT /api/v1/metadata` which will force a new metadata version
of a given set of online roles.


<!--- Please reference the issue(s) this PR fixes. -->
Fixes #399


# Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)


# Additional requirements
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


# Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.rst).

- [x] I agree to follow this project's Code of Conduct