### PR TITLE
Tests: reuse URL strings

### DIFF
--- a/tests/unit/api/test_bootstrap.py
+++ b/tests/unit/api/test_bootstrap.py
@@ -9,10 +9,11 @@ import json
 import pretend
 from fastapi import status
 
+BOOTSTRAP_URL = "/api/v1/bootstrap/"
+
 
 class TestGetBootstrap:
     def test_get_bootstrap_available(self, test_client, monkeypatch):
-        url = "/api/v1/bootstrap/"
         mocked_bootstrap_state = pretend.call_recorder(
             lambda *a: pretend.stub(bootstrap=False, state=None, task_id=None)
         )
@@ -21,9 +22,9 @@ class TestGetBootstrap:
             mocked_bootstrap_state,
         )
 
-        response = test_client.get(url)
+        response = test_client.get(BOOTSTRAP_URL)
         assert response.status_code == status.HTTP_200_OK
-        assert response.url == f"{test_client.base_url}{url}"
+        assert response.url == f"{test_client.base_url}{BOOTSTRAP_URL}"
         assert response.json() == {
             "data": {"bootstrap": False},
             "message": "System available for bootstrap.",
@@ -31,8 +32,6 @@ class TestGetBootstrap:
         assert mocked_bootstrap_state.calls == [pretend.call()]
 
     def test_get_bootstrap_not_available(self, test_client, monkeypatch):
-        url = "/api/v1/bootstrap/"
-
         mocked_bootstrap_state = pretend.call_recorder(
             lambda *a: pretend.stub(
                 bootstrap=True, state="finished", task_id="task_id"
@@ -43,9 +42,9 @@ class TestGetBootstrap:
             mocked_bootstrap_state,
         )
 
-        response = test_client.get(url)
+        response = test_client.get(BOOTSTRAP_URL)
         assert response.status_code == status.HTTP_200_OK
-        assert response.url == f"{test_client.base_url}{url}"
+        assert response.url == f"{test_client.base_url}{BOOTSTRAP_URL}"
         assert response.json() == {
             "data": {"bootstrap": True, "state": "finished", "id": "task_id"},
             "message": "System LOCKED for bootstrap.",
@@ -55,8 +54,6 @@ class TestGetBootstrap:
     def test_get_bootstrap_already_bootstrap_in_pre(
         self, test_client, monkeypatch
     ):
-        url = "/api/v1/bootstrap/"
-
         mocked_bootstrap_state = pretend.call_recorder(
             lambda *a: pretend.stub(
                 bootstrap=False, state="pre", task_id="task_id"
@@ -67,9 +64,9 @@ class TestGetBootstrap:
             mocked_bootstrap_state,
         )
 
-        response = test_client.get(url)
+        response = test_client.get(BOOTSTRAP_URL)
         assert response.status_code == status.HTTP_200_OK
-        assert response.url == f"{test_client.base_url}{url}"
+        assert response.url == f"{test_client.base_url}{BOOTSTRAP_URL}"
         assert response.json() == {
             "data": {"bootstrap": False, "state": "pre", "id": "task_id"},
             "message": "System LOCKED for bootstrap.",
@@ -79,8 +76,6 @@ class TestGetBootstrap:
     def test_get_bootstrap_already_bootstrap_in_signing(
         self, test_client, monkeypatch
     ):
-        url = "/api/v1/bootstrap/"
-
         mocked_bootstrap_state = pretend.call_recorder(
             lambda *a: pretend.stub(
                 bootstrap=False, state="signing", task_id="task_id"
@@ -91,9 +86,9 @@ class TestGetBootstrap:
             mocked_bootstrap_state,
         )
 
-        response = test_client.get(url)
+        response = test_client.get(BOOTSTRAP_URL)
         assert response.status_code == status.HTTP_200_OK
-        assert response.url == f"{test_client.base_url}{url}"
+        assert response.url == f"{test_client.base_url}{BOOTSTRAP_URL}"
         assert response.json() == {
             "data": {"bootstrap": False, "state": "signing", "id": "task_id"},
             "message": "System LOCKED for bootstrap.",
@@ -103,8 +98,6 @@ class TestGetBootstrap:
 
 class TestPostBootstrap:
     def test_post_bootstrap(self, test_client, monkeypatch):
-        url = "/api/v1/bootstrap/"
-
         mocked_bootstrap_state = pretend.call_recorder(
             lambda *a: pretend.stub(
                 bootstrap=False, state="finished", task_id="task_id"
@@ -148,11 +141,11 @@ class TestPostBootstrap:
             f_data = f.read()
         payload = json.loads(f_data)
 
-        response = test_client.post(url, json=payload)
+        response = test_client.post(BOOTSTRAP_URL, json=payload)
 
         assert fake_datetime.now.calls == [pretend.call()]
         assert response.status_code == status.HTTP_202_ACCEPTED
-        assert response.url == f"{test_client.base_url}{url}"
+        assert response.url == f"{test_client.base_url}{BOOTSTRAP_URL}"
         assert response.json() == {
             "message": "Bootstrap accepted.",
             "data": {"task_id": "123", "last_update": "2019-06-16T09:05:01"},
@@ -163,8 +156,6 @@ class TestPostBootstrap:
         ]
 
     def test_post_bootstrap_custom_timeout(self, test_client, monkeypatch):
-        url = "/api/v1/bootstrap/"
-
         mocked_bootstrap_state = pretend.call_recorder(
             lambda *a: pretend.stub(
                 bootstrap=False, state="finished", task_id="task_id"
@@ -209,11 +200,11 @@ class TestPostBootstrap:
         payload = json.loads(f_data)
         payload["timeout"] = 600
 
-        response = test_client.post(url, json=payload)
+        response = test_client.post(BOOTSTRAP_URL, json=payload)
 
         assert fake_datetime.now.calls == [pretend.call()]
         assert response.status_code == status.HTTP_202_ACCEPTED
-        assert response.url == f"{test_client.base_url}{url}"
+        assert response.url == f"{test_client.base_url}{BOOTSTRAP_URL}"
         assert response.json() == {
             "message": "Bootstrap accepted.",
             "data": {"task_id": "123", "last_update": "2019-06-16T09:05:01"},
@@ -224,8 +215,6 @@ class TestPostBootstrap:
         ]
 
     def test_post_bootstrap_already_bootstrap(self, test_client, monkeypatch):
-        url = "/api/v1/bootstrap/"
-
         mocked_bootstrap_state = pretend.call_recorder(
             lambda *a: pretend.stub(
                 bootstrap=True, state="finished", task_id="task_id"
@@ -239,10 +228,10 @@ class TestPostBootstrap:
             f_data = f.read()
 
         payload = json.loads(f_data)
-        response = test_client.post(url, json=payload)
+        response = test_client.post(BOOTSTRAP_URL, json=payload)
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.url == f"{test_client.base_url}{url}"
+        assert response.url == f"{test_client.base_url}{BOOTSTRAP_URL}"
         assert response.json() == {
             "detail": {
                 "error": "System already has a Metadata. State: finished"
@@ -253,8 +242,6 @@ class TestPostBootstrap:
     def test_post_bootstrap_already_bootstrap_in_pre(
         self, test_client, monkeypatch
     ):
-        url = "/api/v1/bootstrap/"
-
         mocked_bootstrap_state = pretend.call_recorder(
             lambda *a: pretend.stub(
                 bootstrap=False, state="pre", task_id="task_id"
@@ -268,10 +255,10 @@ class TestPostBootstrap:
             f_data = f.read()
 
         payload = json.loads(f_data)
-        response = test_client.post(url, json=payload)
+        response = test_client.post(BOOTSTRAP_URL, json=payload)
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.url == f"{test_client.base_url}{url}"
+        assert response.url == f"{test_client.base_url}{BOOTSTRAP_URL}"
         assert response.json() == {
             "detail": {"error": "System already has a Metadata. State: pre"}
         }
@@ -280,8 +267,6 @@ class TestPostBootstrap:
     def test_post_bootstrap_already_bootstrap_in_signing(
         self, test_client, monkeypatch
     ):
-        url = "/api/v1/bootstrap/"
-
         mocked_bootstrap_state = pretend.call_recorder(
             lambda *a: pretend.stub(
                 bootstrap=False, state="signing", task_id="task_id"
@@ -295,10 +280,10 @@ class TestPostBootstrap:
             f_data = f.read()
 
         payload = json.loads(f_data)
-        response = test_client.post(url, json=payload)
+        response = test_client.post(BOOTSTRAP_URL, json=payload)
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.url == f"{test_client.base_url}{url}"
+        assert response.url == f"{test_client.base_url}{BOOTSTRAP_URL}"
         assert response.json() == {
             "detail": {
                 "error": "System already has a Metadata. State: signing"
@@ -307,12 +292,10 @@ class TestPostBootstrap:
         assert mocked_bootstrap_state.calls == [pretend.call()]
 
     def test_post_bootstrap_empty_payload(self, test_client):
-        url = "/api/v1/bootstrap/"
-
-        response = test_client.post(url, json={})
+        response = test_client.post(BOOTSTRAP_URL, json={})
 
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
-        assert response.url == f"{test_client.base_url}{url}"
+        assert response.url == f"{test_client.base_url}{BOOTSTRAP_URL}"
         assert response.json() == {
             "detail": [
                 {
@@ -329,10 +312,8 @@ class TestPostBootstrap:
         }
 
     def test_post_payload_incorrect_md_format(self, test_client):
-        url = "/api/v1/bootstrap/"
-
         payload = {"settings": {}, "metadata": {"timestamp": {}}}
-        response = test_client.post(url, json=payload)
+        response = test_client.post(BOOTSTRAP_URL, json=payload)
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
         assert response.json() == {
             "detail": [

--- a/tests/unit/api/test_targets.py
+++ b/tests/unit/api/test_targets.py
@@ -9,10 +9,13 @@ from uuid import uuid4
 import pretend
 from fastapi import status
 
+ARTIFACTS_URL = "/api/v1/artifacts/"
+ARTIFACTS_DELETE_URL = "/api/v1/artifacts/delete"
+ARTIFACTS_POST_URL = "/api/v1/artifacts/publish/"
+
 
 class TestPostTargets:
     def test_post(self, monkeypatch, test_client):
-        url = "/api/v1/artifacts/"
         with open("tests/data_examples/targets/payload.json") as f:
             f_data = f.read()
 
@@ -44,7 +47,7 @@ class TestPostTargets:
         monkeypatch.setattr(
             "repository_service_tuf_api.targets.datetime", fake_datetime
         )
-        response = test_client.post(url, json=payload)
+        response = test_client.post(ARTIFACTS_URL, json=payload)
         assert response.status_code == status.HTTP_202_ACCEPTED
         assert response.json() == {
             "data": {
@@ -72,7 +75,6 @@ class TestPostTargets:
         ]
 
     def test_post_with_add_task_id_to_custom(self, monkeypatch, test_client):
-        url = "/api/v1/artifacts/"
         with open("tests/data_examples/targets/payload.json") as f:
             f_data = f.read()
 
@@ -108,7 +110,7 @@ class TestPostTargets:
         # enable to add task id to custom metadata field
         payload["add_task_id_to_custom"] = True
 
-        response = test_client.post(url, json=payload)
+        response = test_client.post(ARTIFACTS_URL, json=payload)
         assert response.status_code == status.HTTP_202_ACCEPTED
         assert response.json() == {
             "data": {
@@ -147,7 +149,6 @@ class TestPostTargets:
         ]
 
     def test_post_publish_targets_false(self, monkeypatch, test_client):
-        url = "/api/v1/artifacts/"
         with open("tests/data_examples/targets/payload.json") as f:
             f_data = f.read()
 
@@ -182,7 +183,7 @@ class TestPostTargets:
             "repository_service_tuf_api.targets.repository_metadata",
             mocked_repository_metadata,
         )
-        response = test_client.post(url, json=payload)
+        response = test_client.post(ARTIFACTS_URL, json=payload)
         assert response.status_code == status.HTTP_202_ACCEPTED
         msg = (
             "New Artifact(s) successfully submitted. "
@@ -210,7 +211,6 @@ class TestPostTargets:
         ]
 
     def test_post_without_bootstrap(self, monkeypatch, test_client):
-        url = "/api/v1/artifacts/"
         with open("tests/data_examples/targets/payload.json") as f:
             f_data = f.read()
 
@@ -224,7 +224,7 @@ class TestPostTargets:
 
         payload = json.loads(f_data)
 
-        response = test_client.post(url, json=payload)
+        response = test_client.post(ARTIFACTS_URL, json=payload)
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == {
             "detail": {
@@ -237,7 +237,6 @@ class TestPostTargets:
     def test_post_with_bootstrap_intermediate_state(
         self, monkeypatch, test_client
     ):
-        url = "/api/v1/artifacts/"
         with open("tests/data_examples/targets/payload.json") as f:
             f_data = f.read()
 
@@ -251,7 +250,7 @@ class TestPostTargets:
 
         payload = json.loads(f_data)
 
-        response = test_client.post(url, json=payload)
+        response = test_client.post(ARTIFACTS_URL, json=payload)
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == {
             "detail": {
@@ -262,7 +261,6 @@ class TestPostTargets:
         assert mocked_bootstrap_state.calls == [pretend.call()]
 
     def test_post_missing_required_field(self, test_client):
-        url = "/api/v1/artifacts/"
         payload = {
             "targets": [
                 {
@@ -274,14 +272,12 @@ class TestPostTargets:
             ]
         }
 
-        response = test_client.post(url, json=payload)
+        response = test_client.post(ARTIFACTS_URL, json=payload)
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
 
 class TestPostTargetsDelete:
     def test_post_delete(self, monkeypatch, test_client):
-        url = "/api/v1/artifacts/delete"
-
         payload = {
             "targets": ["file-v1.0.0_i683.tar.gz", "v0.4.1/file.tar.gz"],
         }
@@ -313,7 +309,7 @@ class TestPostTargetsDelete:
             "repository_service_tuf_api.targets.datetime", fake_datetime
         )
 
-        response = test_client.post(url, json=payload)
+        response = test_client.post(ARTIFACTS_DELETE_URL, json=payload)
 
         assert fake_datetime.now.calls == [pretend.call()]
         assert response.status_code == status.HTTP_202_ACCEPTED
@@ -339,8 +335,6 @@ class TestPostTargetsDelete:
         ]
 
     def test_post_publish_targets_delete_false(self, monkeypatch, test_client):
-        url = "/api/v1/artifacts/delete"
-
         payload = {
             "targets": ["file-v1.0.0_i683.tar.gz", "v0.4.1/file.tar.gz"],
             "publish_targets": False,
@@ -373,7 +367,7 @@ class TestPostTargetsDelete:
             "repository_service_tuf_api.targets.datetime", fake_datetime
         )
 
-        response = test_client.post(url, json=payload)
+        response = test_client.post(ARTIFACTS_DELETE_URL, json=payload)
 
         assert response.status_code == status.HTTP_202_ACCEPTED
         msg = (
@@ -402,8 +396,6 @@ class TestPostTargetsDelete:
         ]
 
     def test_post_without_bootstrap_delete(self, monkeypatch, test_client):
-        url = "/api/v1/artifacts/delete"
-
         payload = {
             "targets": ["file-v1.0.0_i683.tar.gz", "v0.4.1/file.tar.gz"]
         }
@@ -414,7 +406,7 @@ class TestPostTargetsDelete:
             "repository_service_tuf_api.targets.bootstrap_state",
             mocked_bootstrap_state,
         )
-        response = test_client.post(url, json=payload)
+        response = test_client.post(ARTIFACTS_DELETE_URL, json=payload)
 
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == {
@@ -428,8 +420,6 @@ class TestPostTargetsDelete:
     def test_post_with_bootstrap_intermediate_state_delete(
         self, monkeypatch, test_client
     ):
-        url = "/api/v1/artifacts/delete"
-
         payload = {
             "targets": ["file-v1.0.0_i683.tar.gz", "v0.4.1/file.tar.gz"]
         }
@@ -440,7 +430,7 @@ class TestPostTargetsDelete:
             "repository_service_tuf_api.targets.bootstrap_state",
             mocked_bootstrap_state,
         )
-        response = test_client.post(url, json=payload)
+        response = test_client.post(ARTIFACTS_DELETE_URL, json=payload)
 
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == {
@@ -451,19 +441,15 @@ class TestPostTargetsDelete:
         }
 
     def test_post_missing_required_field_delete(self, test_client):
-        url = "/api/v1/artifacts/delete"
-
         payload = {"paths": ["file-v1.0.0_i683.tar.gz", "v0.4.1/file.tar.gz"]}
 
-        response = test_client.post(url, json=payload)
+        response = test_client.post(ARTIFACTS_DELETE_URL, json=payload)
 
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
 
 class TestPostTargetsPublish:
     def test_post_publish(self, monkeypatch, test_client):
-        url = "/api/v1/artifacts/publish/"
-
         mocked_repository_metadata = pretend.stub(
             apply_async=pretend.call_recorder(lambda **kw: None)
         )
@@ -483,7 +469,7 @@ class TestPostTargetsPublish:
         monkeypatch.setattr(
             "repository_service_tuf_api.targets.datetime", fake_datetime
         )
-        response = test_client.post(url)
+        response = test_client.post(ARTIFACTS_POST_URL)
         assert response.status_code == status.HTTP_202_ACCEPTED
         assert response.json() == {
             "data": {

--- a/tests/unit/api/test_tasks.py
+++ b/tests/unit/api/test_tasks.py
@@ -6,11 +6,11 @@
 import pretend
 from fastapi import status
 
+TASK_URL = "/api/v1/task/"
+
 
 class TestGetTask:
     def test_get(self, test_client, monkeypatch):
-        url = "/api/v1/task/"
-
         mocked_task_result = pretend.stub(
             state="SUCCESS",
             result={
@@ -28,7 +28,7 @@ class TestGetTask:
             mocked_repository_metadata,
         )
 
-        test_response = test_client.get(f"{url}?task_id=test_id")
+        test_response = test_client.get(f"{TASK_URL}?task_id=test_id")
         assert test_response.status_code == status.HTTP_200_OK
         assert test_response.json() == {
             "data": {
@@ -48,8 +48,6 @@ class TestGetTask:
         ]
 
     def test_get_result_is_exception(self, test_client, monkeypatch):
-        url = "/api/v1/task/"
-
         mocked_task_result = pretend.stub(
             state="SUCCESS", result=ValueError("Failed to load")
         )
@@ -61,7 +59,7 @@ class TestGetTask:
             mocked_repository_metadata,
         )
 
-        test_response = test_client.get(f"{url}?task_id=test_id")
+        test_response = test_client.get(f"{TASK_URL}?task_id=test_id")
         assert test_response.status_code == status.HTTP_200_OK
         assert test_response.json() == {
             "data": {


### PR DESCRIPTION
A small simplification of how we define ULR strings in our tests and make
sure we do reuse them instead of defining them in each test.

Signed-off-by: Martin Vrachev <martin.vrachev@broadcom.com>