### PR TITLE
refactoring: update the task response data in the `/api/v1/tasks`

### DIFF
--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1606,6 +1606,7 @@
                     "REJECTED",
                     "RETRY",
                     "IGNORED",
+                    "ERRORED",
                     "RUNNING"
                 ],
                 "title": "TaskState",
@@ -1624,7 +1625,7 @@
                                 "$ref": "#/components/schemas/TaskState"
                             }
                         ],
-                        "description": "The Celery task state. Note: It isn't the task result status.\n\n`PENDING`: Task state is unknown (assumed pending since you know the id).\n\n`RECEIVED`: Task received by a worker (only used in events).\n\n`STARTED`: Task started by a worker.\n\n`RUNNING`: Task is running.\n\n`SUCCESS`: Task succeeded.\n\n`FAILURE`: Task failed.\n\n`REVOKED`: Task revoked.\n\n`REJECTED`: Task was rejected (only used in events).\n\n"
+                        "description": "The Celery task state. Note: It isn't the task result status.\n\n`PENDING`: Task state is unknown (assumed pending since you know the id).\n\n`RECEIVED`: Task received by a worker (only used in events).\n\n`STARTED`: Task started by a worker.\n\n`RUNNING`: Task is running.\n\n`SUCCESS`: Task succeeded.\n\n`FAILURE`: Task failed.\n\n`ERRORED`: Task errored.\n\n`REVOKED`: Task revoked.\n\n`REJECTED`: Task was rejected (only used in events).\n\n"
                     },
                     "result": {
                         "anyOf": [

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1528,8 +1528,9 @@
                         "title": "Error",
                         "description": "If the task status result is `False` shows an error message"
                     },
-                    "any": {
-                        "title": "Any",
+                    "details": {
+                        "type": "object",
+                        "title": "Details",
                         "description": "Any releavant information from task"
                     }
                 },
@@ -1625,7 +1626,7 @@
                                 "$ref": "#/components/schemas/TaskState"
                             }
                         ],
-                        "description": "The Celery task state. Note: It isn't the task result status.\n\n`PENDING`: Task state is unknown (assumed pending since you know the id).\n\n`RECEIVED`: Task received by a worker (only used in events).\n\n`STARTED`: Task started by a worker.\n\n`RUNNING`: Task is running.\n\n`SUCCESS`: Task succeeded.\n\n`FAILURE`: Task failed.\n\n`ERRORED`: Task errored.\n\n`REVOKED`: Task revoked.\n\n`REJECTED`: Task was rejected (only used in events).\n\n"
+                        "description": "The Celery task state. Note: It isn't the task result status.\n\n`PENDING`: Task state is unknown (assumed pending since you know the id).\n\n`RECEIVED`: Task received by a worker (only used in events).\n\n`STARTED`: Task started by a worker.\n\n`RUNNING`: Task is running.\n\n`SUCCESS`: Task succeeded.\n\n`FAILURE`: Task failed.\n\n`ERRORED`: Task errored. RSTUF identified an error while processing the task.\n\n`REVOKED`: Task revoked.\n\n`REJECTED`: Task was rejected (only used in events).\n\n"
                     },
                     "result": {
                         "anyOf": [
@@ -1837,11 +1838,17 @@
                         "task_id": "33e66671dcc84cdfa2535a1eb030104c",
                         "state": "SUCCESS",
                         "result": {
-                            "status": true,
                             "task": "add_targets",
+                            "status": true,
                             "last_update": "2023-11-17T09:54:15.762882",
+                            "message": "Target(s) Added",
                             "details": {
-                                "message": "Target(s) Added"
+                                "targets": [
+                                    "file1.tar.gz"
+                                ],
+                                "target_roles": [
+                                    "bins-3"
+                                ]
                             }
                         }
                     },

--- a/repository_service_tuf_api/tasks.py
+++ b/repository_service_tuf_api/tasks.py
@@ -128,7 +128,9 @@ def get(task_id: str) -> Response:
 
     if isinstance(task.result, Exception):
         task_result = str(task.result)
-    elif task_state == TaskState.SUCCESS and not task_result["status"]:
+    elif task_state == TaskState.SUCCESS and not task_result.get(
+        "status", False
+    ):
         task_state = TaskState.ERRORED
 
     return Response(

--- a/repository_service_tuf_api/tasks.py
+++ b/repository_service_tuf_api/tasks.py
@@ -5,7 +5,7 @@
 
 import enum
 from datetime import datetime
-from typing import Any, Optional, Union
+from typing import Any, Dict, Optional, Union
 
 from celery import states
 from pydantic import BaseModel, Field
@@ -49,7 +49,9 @@ class TaskDetails(BaseModel):
             "If the task status result is `False` shows an error message"
         )
     )
-    any: Any = Field(description="Any releavant information from task")
+    details: Optional[Dict[str, Any]] = Field(
+        description="Any releavant information from task"
+    )
 
 
 class TaskResult(BaseModel):
@@ -73,7 +75,8 @@ class TasksData(BaseModel):
             "`RUNNING`: Task is running.\n\n"
             "`SUCCESS`: Task succeeded.\n\n"
             "`FAILURE`: Task failed.\n\n"
-            "`ERRORED`: Task errored.\n\n"
+            "`ERRORED`: Task errored. RSTUF identified an error while "
+            "processing the task.\n\n"
             "`REVOKED`: Task revoked.\n\n"
             "`REJECTED`: Task was rejected (only used in events).\n\n"
         )
@@ -95,10 +98,14 @@ class Response(BaseModel):
                 "task_id": "33e66671dcc84cdfa2535a1eb030104c",
                 "state": TaskState.SUCCESS,
                 "result": {
-                    "status": True,
                     "task": TaskName.ADD_TARGETS,
+                    "status": True,
                     "last_update": "2023-11-17T09:54:15.762882",
-                    "details": {"message": "Target(s) Added"},
+                    "message": "Target(s) Added",
+                    "details": {
+                        "targets": ["file1.tar.gz"],
+                        "target_roles": ["bins-3"],
+                    },
                 },
             },
             "message": "Task state.",
@@ -127,7 +134,7 @@ def get(task_id: str) -> Response:
     task_result = task.result
 
     if isinstance(task.result, Exception):
-        task_result = str(task.result)
+        task_result = {"message": str(task.result)}
     elif task_state == TaskState.SUCCESS and not task_result.get(
         "status", False
     ):

--- a/tests/unit/api/test_tasks.py
+++ b/tests/unit/api/test_tasks.py
@@ -19,7 +19,14 @@ class TestGetTask:
                 "last_update": "2023-11-17T09:54:15.762882",
                 "message": "Target(s) Added",
                 "error": None,
-                "details": {},
+                "details": {
+                    "targets": [
+                        "file1.tar.gz",
+                        "file2.tar.gz",
+                        "file3.tar.gz",
+                    ],
+                    "target_roles": ["bins-3", "bins-2"],
+                },
             },
         )
         mocked_repository_metadata = pretend.stub(
@@ -41,7 +48,14 @@ class TestGetTask:
                     "task": "add_targets",
                     "last_update": "2023-11-17T09:54:15.762882",
                     "message": "Target(s) Added",
-                    "details": {},
+                    "details": {
+                        "targets": [
+                            "file1.tar.gz",
+                            "file2.tar.gz",
+                            "file3.tar.gz",
+                        ],
+                        "target_roles": ["bins-3", "bins-2"],
+                    },
                 },
             },
             "message": "Task state.",
@@ -68,7 +82,7 @@ class TestGetTask:
             "data": {
                 "task_id": "test_id",
                 "state": "SUCCESS",
-                "result": "Failed to load",
+                "result": {"message": "Failed to load"},
             },
             "message": "Task state.",
         }
@@ -85,7 +99,7 @@ class TestGetTask:
                 "last_update": "2023-11-17T09:54:15.762882",
                 "message": "Signature Failed",
                 "error": "No signatures pending for root",
-                "details": {},
+                "details": None,
             },
         )
         mocked_repository_metadata = pretend.stub(
@@ -109,7 +123,6 @@ class TestGetTask:
                     "last_update": "2023-11-17T09:54:15.762882",
                     "message": "Signature Failed",
                     "error": "No signatures pending for root",
-                    "details": {},
                 },
             },
             "message": "Task state.",

--- a/tests/unit/api/test_tasks.py
+++ b/tests/unit/api/test_tasks.py
@@ -17,9 +17,9 @@ class TestGetTask:
                 "status": True,
                 "task": "add_targets",
                 "last_update": "2023-11-17T09:54:15.762882",
-                "message": None,
+                "message": "Target(s) Added",
                 "error": None,
-                "details": {"message": "Target(s) Added"},
+                "details": {},
             },
         )
         mocked_repository_metadata = pretend.stub(
@@ -40,7 +40,8 @@ class TestGetTask:
                     "status": True,
                     "task": "add_targets",
                     "last_update": "2023-11-17T09:54:15.762882",
-                    "details": {"message": "Target(s) Added"},
+                    "message": "Target(s) Added",
+                    "details": {},
                 },
             },
             "message": "Task state.",

--- a/tests/unit/api/test_tasks.py
+++ b/tests/unit/api/test_tasks.py
@@ -116,3 +116,63 @@ class TestGetTask:
         assert mocked_repository_metadata.AsyncResult.calls == [
             pretend.call("test_id")
         ]
+
+    def test_get_result_success_with_empty_result(
+        self, test_client, monkeypatch
+    ):
+        mocked_task_result = pretend.stub(
+            state="SUCCESS",
+            result={},
+        )
+        mocked_repository_metadata = pretend.stub(
+            AsyncResult=pretend.call_recorder(lambda t: mocked_task_result)
+        )
+        monkeypatch.setattr(
+            "repository_service_tuf_api.tasks.repository_metadata",
+            mocked_repository_metadata,
+        )
+
+        test_response = test_client.get(f"{TASK_URL}?task_id=test_id")
+        assert test_response.status_code == status.HTTP_200_OK
+
+        assert test_response.json() == {
+            "data": {
+                "task_id": "test_id",
+                "state": "ERRORED",
+                "result": {},
+            },
+            "message": "Task state.",
+        }
+        assert mocked_repository_metadata.AsyncResult.calls == [
+            pretend.call("test_id")
+        ]
+
+    def test_get_result_failure_with_empty_result(
+        self, test_client, monkeypatch
+    ):
+        mocked_task_result = pretend.stub(
+            state="FAILURE",
+            result={},
+        )
+        mocked_repository_metadata = pretend.stub(
+            AsyncResult=pretend.call_recorder(lambda t: mocked_task_result)
+        )
+        monkeypatch.setattr(
+            "repository_service_tuf_api.tasks.repository_metadata",
+            mocked_repository_metadata,
+        )
+
+        test_response = test_client.get(f"{TASK_URL}?task_id=test_id")
+        assert test_response.status_code == status.HTTP_200_OK
+
+        assert test_response.json() == {
+            "data": {
+                "task_id": "test_id",
+                "state": "FAILURE",
+                "result": {},
+            },
+            "message": "Task state.",
+        }
+        assert mocked_repository_metadata.AsyncResult.calls == [
+            pretend.call("test_id")
+        ]

--- a/tests/unit/api/test_tasks.py
+++ b/tests/unit/api/test_tasks.py
@@ -17,6 +17,8 @@ class TestGetTask:
                 "status": True,
                 "task": "add_targets",
                 "last_update": "2023-11-17T09:54:15.762882",
+                "message": None,
+                "error": None,
                 "details": {"message": "Target(s) Added"},
             },
         )
@@ -80,7 +82,9 @@ class TestGetTask:
                 "status": False,
                 "task": "sign_metadata",
                 "last_update": "2023-11-17T09:54:15.762882",
-                "details": {"message": "Signature Failed"},
+                "message": "Signature Failed",
+                "error": "No signatures pending for root",
+                "details": {},
             },
         )
         mocked_repository_metadata = pretend.stub(
@@ -102,7 +106,9 @@ class TestGetTask:
                     "status": False,
                     "task": "sign_metadata",
                     "last_update": "2023-11-17T09:54:15.762882",
-                    "details": {"message": "Signature Failed"},
+                    "message": "Signature Failed",
+                    "error": "No signatures pending for root",
+                    "details": {},
                 },
             },
             "message": "Task state.",


### PR DESCRIPTION
… a error, false status

<!--- Thanks for taking the time to fill out this pull request! -->
<!--- Please fill in the fields below to submit a pull request. 
The more information provided, the better. -->

<!---  -->

# Description
This is a request coming from RubyGems maintainers that it would be better and easier for them
if they can understand that a task has failed or errored based on the returned state instead of parsing
the result and checking the status.
This will also improve all future clients.


The more detailed changes are:

The `data.state` now includes the `ERRORED` state, an error identified by RSTUF while processing a task. This error was identified and handled by RSTUF, but might require attention from the user. Details will be included in `data.result`.
<img width="491" alt="Screenshot 2024-01-30 at 06 33 36" src="https://github.com/repository-service-tuf/repository-service-tuf-api/assets/546882/73230167-267b-4393-8a24-014addfcbb06">

The `data.result` now is a `Dict[string, Any]`. Before, it was `string` or `Dict[string, Any]`. The string was used in case of exception, which now has the same consistency.
<img width="435" alt="Screenshot 2024-01-30 at 06 38 17" src="https://github.com/repository-service-tuf/repository-service-tuf-api/assets/546882/2cfb6d2b-e31d-4c5c-a741-21e78b84c39c">

Success tasks will follow as
<img width="1233" alt="Screenshot 2024-01-30 at 06 38 57" src="https://github.com/repository-service-tuf/repository-service-tuf-api/assets/546882/7915fd47-e763-4158-8700-ec1075ac22f3">



<!--- Please reference the issue(s) this PR fixes. -->
Fixes #515 


# Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)


# Additional requirements
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


# Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.rst).

- [x] I agree to follow this project's Code of Conduct