### PR TITLE
Feature: support to unrecognized fields (Root)

### DIFF
--- a/repository_service_tuf_api/common_models.py
+++ b/repository_service_tuf_api/common_models.py
@@ -87,7 +87,7 @@ class TUFSigned(BaseModel):
     class Config:
         fields = {"type": "_type"}
         # allow extra unrecognized fields (but it will be validated)
-        # https://docs.pydantic.dev/latest/api/config/#pydantic.config.ConfigDict.extra
+        # https://docs.pydantic.dev/1.10/usage/model_config/#options
         extra = Extra.allow
 
     # Custom Validator for the extra fields (TUF unrecognized_fields)

--- a/repository_service_tuf_api/common_models.py
+++ b/repository_service_tuf_api/common_models.py
@@ -4,9 +4,9 @@
 # SPDX-License-Identifier: MIT
 
 from enum import Enum
-from typing import Dict, List, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Extra, Field, root_validator
 
 
 class Roles(Enum):
@@ -86,6 +86,36 @@ class TUFSigned(BaseModel):
 
     class Config:
         fields = {"type": "_type"}
+        # https://docs.pydantic.dev/latest/api/config/#pydantic.config.ConfigDict.extra
+        model_config = ConfigDict(
+            extra="allow",
+        )
+        extra = (
+            Extra.allow
+        )  # allow extra unrecognized fields (but it will be validated)
+
+    # Custom Validator for the extra fields (TUF unrecognized_fields)
+    @root_validator(pre=True)
+    def validate_unrecognized_fields(
+        cls, values: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        all_required_field_names = {
+            field.alias
+            for field in cls.__fields__.values()
+            if field.alias != "extra"  # to support alias
+        }
+
+        for field_name in list(values):
+            if field_name not in all_required_field_names:
+                if (
+                    not field_name.startswith("x")
+                    or len(field_name.split("-")) < 3
+                ):
+                    raise ValueError(
+                        f"Invalid: `{field_name}` field name, "
+                        "unrecognized_field must use format x-<vendor>-<name>"
+                    )
+        return values
 
 
 class TUFSignatures(BaseModel):

--- a/repository_service_tuf_api/common_models.py
+++ b/repository_service_tuf_api/common_models.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Repository Service for TUF Contributors
+# SPDX-FileCopyrightText: 2023-2024 Repository Service for TUF Contributors
 # SPDX-FileCopyrightText: 2022-2023 VMware Inc
 #
 # SPDX-License-Identifier: MIT
@@ -6,7 +6,7 @@
 from enum import Enum
 from typing import Any, Dict, List, Literal, Optional
 
-from pydantic import BaseModel, ConfigDict, Extra, Field, root_validator
+from pydantic import BaseModel, Extra, Field, root_validator
 
 
 class Roles(Enum):
@@ -86,13 +86,9 @@ class TUFSigned(BaseModel):
 
     class Config:
         fields = {"type": "_type"}
+        # allow extra unrecognized fields (but it will be validated)
         # https://docs.pydantic.dev/latest/api/config/#pydantic.config.ConfigDict.extra
-        model_config = ConfigDict(
-            extra="allow",
-        )
-        extra = (
-            Extra.allow
-        )  # allow extra unrecognized fields (but it will be validated)
+        extra = Extra.allow
 
     # Custom Validator for the extra fields (TUF unrecognized_fields)
     @root_validator(pre=True)
@@ -100,9 +96,7 @@ class TUFSigned(BaseModel):
         cls, values: Dict[str, Any]
     ) -> Dict[str, Any]:
         all_required_field_names = {
-            field.alias
-            for field in cls.__fields__.values()
-            if field.alias != "extra"  # to support alias
+            field.alias for field in cls.__fields__.values()
         }
 
         for field_name in list(values):

--- a/tests/unit/api/test_bootstrap.py
+++ b/tests/unit/api/test_bootstrap.py
@@ -155,6 +155,150 @@ class TestPostBootstrap:
             pretend.call(task_id="123", timeout=300)
         ]
 
+    def test_post_bootstrap_unrecognized_field(self, test_client, monkeypatch):
+        mocked_bootstrap_state = pretend.call_recorder(
+            lambda *a: pretend.stub(
+                bootstrap=False, state="finished", task_id="task_id"
+            )
+        )
+        monkeypatch.setattr(
+            "repository_service_tuf_api.bootstrap.bootstrap_state",
+            mocked_bootstrap_state,
+        )
+        mocked_async_result = pretend.stub(state="SUCCESS")
+        mocked_repository_metadata = pretend.stub(
+            apply_async=pretend.call_recorder(lambda *a, **kw: None),
+            AsyncResult=pretend.call_recorder(lambda *a: mocked_async_result),
+        )
+        monkeypatch.setattr(
+            "repository_service_tuf_api.bootstrap.repository_metadata",
+            mocked_repository_metadata,
+        )
+        monkeypatch.setattr(
+            "repository_service_tuf_api.bootstrap.get_task_id", lambda: "123"
+        )
+        monkeypatch.setattr(
+            "repository_service_tuf_api.bootstrap.pre_lock_bootstrap",
+            lambda *a: None,
+        )
+        mocked__check_bootstrap_status = pretend.call_recorder(lambda *a: None)
+        monkeypatch.setattr(
+            "repository_service_tuf_api.bootstrap._check_bootstrap_status",
+            mocked__check_bootstrap_status,
+        )
+
+        fake_time = datetime.datetime(2019, 6, 16, 9, 5, 1)
+        fake_datetime = pretend.stub(
+            now=pretend.call_recorder(lambda: fake_time)
+        )
+        monkeypatch.setattr(
+            "repository_service_tuf_api.bootstrap.datetime", fake_datetime
+        )
+
+        with open("tests/data_examples/bootstrap/payload.json") as f:
+            f_data = f.read()
+        payload = json.loads(f_data)
+        payload["metadata"]["root"]["signed"]["x-v-n-url"] = "http://url.com"
+        response = test_client.post(BOOTSTRAP_URL, json=payload)
+
+        assert fake_datetime.now.calls == [pretend.call()]
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        assert response.url == f"{test_client.base_url}{BOOTSTRAP_URL}"
+        assert response.json() == {
+            "message": "Bootstrap accepted.",
+            "data": {"task_id": "123", "last_update": "2019-06-16T09:05:01"},
+        }
+        assert mocked_bootstrap_state.calls == [pretend.call()]
+        assert mocked__check_bootstrap_status.calls == [
+            pretend.call(task_id="123", timeout=300)
+        ]
+
+    def test_post_bootstrap_unrecognized_field_invalid(
+        self, test_client, monkeypatch
+    ):
+        mocked_bootstrap_state = pretend.call_recorder(
+            lambda *a: pretend.stub(
+                bootstrap=False, state="finished", task_id="task_id"
+            )
+        )
+        monkeypatch.setattr(
+            "repository_service_tuf_api.bootstrap.bootstrap_state",
+            mocked_bootstrap_state,
+        )
+        mocked_async_result = pretend.stub(state="SUCCESS")
+        mocked_repository_metadata = pretend.stub(
+            apply_async=pretend.call_recorder(lambda *a, **kw: None),
+            AsyncResult=pretend.call_recorder(lambda *a: mocked_async_result),
+        )
+        monkeypatch.setattr(
+            "repository_service_tuf_api.bootstrap.repository_metadata",
+            mocked_repository_metadata,
+        )
+        monkeypatch.setattr(
+            "repository_service_tuf_api.bootstrap.get_task_id", lambda: "123"
+        )
+        monkeypatch.setattr(
+            "repository_service_tuf_api.bootstrap.pre_lock_bootstrap",
+            lambda *a: None,
+        )
+
+        with open("tests/data_examples/bootstrap/payload.json") as f:
+            f_data = f.read()
+        payload = json.loads(f_data)
+        payload["metadata"]["root"]["signed"]["x-url"] = "http://example.com"
+
+        response = test_client.post(BOOTSTRAP_URL, json=payload)
+
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert response.url == f"{test_client.base_url}{BOOTSTRAP_URL}"
+        assert (
+            "unrecognized_field must use format x-<vendor>-<name>"
+            in response.text
+        )
+
+    def test_post_bootstrap_unrecognized_field_must_start_with_x(
+        self, test_client, monkeypatch
+    ):
+        mocked_bootstrap_state = pretend.call_recorder(
+            lambda *a: pretend.stub(
+                bootstrap=False, state="finished", task_id="task_id"
+            )
+        )
+        monkeypatch.setattr(
+            "repository_service_tuf_api.bootstrap.bootstrap_state",
+            mocked_bootstrap_state,
+        )
+        mocked_async_result = pretend.stub(state="SUCCESS")
+        mocked_repository_metadata = pretend.stub(
+            apply_async=pretend.call_recorder(lambda *a, **kw: None),
+            AsyncResult=pretend.call_recorder(lambda *a: mocked_async_result),
+        )
+        monkeypatch.setattr(
+            "repository_service_tuf_api.bootstrap.repository_metadata",
+            mocked_repository_metadata,
+        )
+        monkeypatch.setattr(
+            "repository_service_tuf_api.bootstrap.get_task_id", lambda: "123"
+        )
+        monkeypatch.setattr(
+            "repository_service_tuf_api.bootstrap.pre_lock_bootstrap",
+            lambda *a: None,
+        )
+
+        with open("tests/data_examples/bootstrap/payload.json") as f:
+            f_data = f.read()
+        payload = json.loads(f_data)
+        payload["metadata"]["root"]["signed"]["vendor-url"] = "http://url.com"
+
+        response = test_client.post(BOOTSTRAP_URL, json=payload)
+
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert response.url == f"{test_client.base_url}{BOOTSTRAP_URL}"
+        assert (
+            "unrecognized_field must use format x-<vendor>-<name>"
+            in response.text
+        )
+
     def test_post_bootstrap_custom_timeout(self, test_client, monkeypatch):
         mocked_bootstrap_state = pretend.call_recorder(
             lambda *a: pretend.stub(


### PR DESCRIPTION
# Description
This commit adds the support to unrecognized fields to the Root.

The Root.signed.unrecognized_fields can store relevant information in the TUF metadata used by TUF clients or even RSTUF Worker.

It is added to the `TUFSigned`, allowing extra fields. The unrecognized fields must to have the format `x-<vendor>-<name>`

We add a pydantic `root_validator` to verify all extra fields if they follow the required format.

<!--- Please reference the issue(s) this PR fixes. -->
Part of https://github.com/repository-service-tuf/repository-service-tuf/issues/608


# Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)


# Additional requirements
- [x] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


# Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.rst).

- [x] I agree to follow this project's Code of Conduct

# Note:
This support works with RSTUF Worker which doesn't require changes.
