### PR TITLE
feat: include RSTUF unrecognized fields in the keys

### DIFF
--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1225,7 +1225,18 @@
                     },
                     "name": {
                         "type": "string",
-                        "title": "Name"
+                        "title": "Name",
+                        "description": "Use x-rstuf-key-name instead. Key Name"
+                    },
+                    "x-rstuf-key-name": {
+                        "type": "string",
+                        "title": "X-Rstuf-Key-Name",
+                        "description": "Key Name"
+                    },
+                    "x-rstuf-online-key-uri": {
+                        "type": "string",
+                        "title": "X-Rstuf-Online-Key-Uri",
+                        "description": "Online Key URI"
                     }
                 },
                 "type": "object",

--- a/repository_service_tuf_api/common_models.py
+++ b/repository_service_tuf_api/common_models.py
@@ -54,7 +54,15 @@ class TUFKeys(BaseModel):
     keytype: str
     scheme: str
     keyval: Dict[Literal["public", "private"], str]
-    name: Optional[str]
+    name: Optional[str] = Field(
+        description="Use x-rstuf-key-name instead. Key Name"
+    )
+    x_rstuf_key_name: Optional[str] = Field(
+        alias="x-rstuf-key-name", description="Key Name"
+    )
+    x_rstuf_online_key_uri: Optional[str] = Field(
+        alias="x-rstuf-online-key-uri", description="Online Key URI"
+    )
 
 
 class TUFSignedDelegations(BaseModel):


### PR DESCRIPTION

# Description

Add two unrecognized fields in the keys for the TUF metadata

- `x-rstuf-key-name` to store key names
- `x-rstuf-online-key-uri` to be used by online keys to store the URI used by secure systems lib.
  This field is part of several changes being done in the RSTUF Worker and the CLI to make the signers simpler. This support was added on RSTUF Worker.
  Reference: https://github.com/repository-service-tuf/repository-service-tuf-worker/commit/b70143c0a5a8c8b5a647c73bfd1129684297998c

# Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)


# Additional requirements
- [ ] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


# Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.rst).

- [x] I agree to follow this project's Code of Conduct