### PR TITLE
Force UTC timezone for all datetime objects

### DIFF
--- a/repository_service_tuf_api/artifacts.py
+++ b/repository_service_tuf_api/artifacts.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: MIT
 
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List
 
 from fastapi import HTTPException, status
@@ -201,7 +201,7 @@ def post(payload: AddPayload) -> ResponsePostAdd:
     data = {
         "artifacts": [artifact.path for artifact in payload.artifacts],
         "task_id": task_id,
-        "last_update": datetime.now(),
+        "last_update": datetime.now(timezone.utc),
     }
     return ResponsePostAdd(data=data, message=message)
 
@@ -239,7 +239,7 @@ def delete(payload: DeletePayload) -> ResponsePostDelete:
     data = {
         "artifacts": payload.artifacts,
         "task_id": task_id,
-        "last_update": datetime.now(),
+        "last_update": datetime.now(timezone.utc),
     }
 
     message = "Remove Artifact(s) successfully submitted."
@@ -263,7 +263,7 @@ def post_publish_artifacts() -> ResponsePostPublish:
     data = {
         "artifacts": [],
         "task_id": task_id,
-        "last_update": datetime.now(),
+        "last_update": datetime.now(timezone.utc),
     }
 
     return ResponsePostPublish(

--- a/repository_service_tuf_api/bootstrap.py
+++ b/repository_service_tuf_api/bootstrap.py
@@ -7,7 +7,7 @@ import json
 import logging
 import re
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from threading import Thread
 from typing import Any, Dict, List, Optional
 
@@ -233,7 +233,7 @@ def post_bootstrap(payload: BootstrapPayload) -> BootstrapPostResponse:
 
     data = {
         "task_id": task_id,
-        "last_update": datetime.now(),
+        "last_update": datetime.now(timezone.utc),
     }
 
     return BootstrapPostResponse(

--- a/repository_service_tuf_api/config.py
+++ b/repository_service_tuf_api/config.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: MIT
 
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict
 
 from fastapi import HTTPException, status
@@ -85,7 +85,7 @@ def put(payload: PutPayload):
 
     data = {
         "task_id": task_id,
-        "last_update": datetime.now(),
+        "last_update": datetime.now(timezone.utc),
     }
 
     return PutResponse(data=data, message="Settings successfully submitted.")

--- a/repository_service_tuf_api/metadata.py
+++ b/repository_service_tuf_api/metadata.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: MIT
 
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, Literal
 
 from fastapi import HTTPException, status
@@ -83,7 +83,7 @@ def post_metadata(payload: MetadataPostPayload) -> MetadataPostResponse:
     message = "Metadata update accepted."
     data = {
         "task_id": task_id,
-        "last_update": datetime.now(),
+        "last_update": datetime.now(timezone.utc),
     }
     return MetadataPostResponse(data=data, message=message)
 
@@ -224,7 +224,7 @@ def post_metadata_sign(
     message = "Metadata sign accepted."
     data = {
         "task_id": task_id,
-        "last_update": datetime.now(),
+        "last_update": datetime.now(timezone.utc),
     }
 
     return MetadataPostResponse(data=data, message=message)
@@ -283,7 +283,7 @@ def delete_metadata_sign(payload: MetadataSignDeletePayload):
     message = "Metadata sign delete accepted."
     data = {
         "task_id": task_id,
-        "last_update": datetime.now(),
+        "last_update": datetime.now(timezone.utc),
     }
 
     return MetadataSignDeleteResponse(data=data, message=message)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,9 @@
 # SPDX-FileCopyrightText: 2022-2023 VMware Inc
 #
 # SPDX-License-Identifier: MIT
+from datetime import datetime, timezone
+
+import pretend
 import pytest
 from fastapi.testclient import TestClient
 
@@ -13,3 +16,9 @@ def test_client(monkeypatch):
     client = TestClient(rstuf_app)
 
     return client
+
+
+@pytest.fixture()
+def fake_datetime(monkeypatch):
+    fake_time = datetime(2019, 6, 16, 9, 5, 1, tzinfo=timezone.utc)
+    return pretend.stub(now=pretend.call_recorder(lambda a: fake_time))

--- a/tests/unit/api/test_tasks.py
+++ b/tests/unit/api/test_tasks.py
@@ -7,6 +7,7 @@ import pretend
 from fastapi import status
 
 TASK_URL = "/api/v1/task/"
+MOCK_PATH = "repository_service_tuf_api.tasks"
 
 
 class TestGetTask:
@@ -33,8 +34,7 @@ class TestGetTask:
             AsyncResult=pretend.call_recorder(lambda t: mocked_task_result)
         )
         monkeypatch.setattr(
-            "repository_service_tuf_api.tasks.repository_metadata",
-            mocked_repository_metadata,
+            f"{MOCK_PATH}.repository_metadata", mocked_repository_metadata
         )
 
         test_response = test_client.get(f"{TASK_URL}?task_id=test_id")
@@ -73,8 +73,7 @@ class TestGetTask:
             AsyncResult=pretend.call_recorder(lambda t: mocked_task_result)
         )
         monkeypatch.setattr(
-            "repository_service_tuf_api.tasks.repository_metadata",
-            mocked_repository_metadata,
+            f"{MOCK_PATH}.repository_metadata", mocked_repository_metadata
         )
 
         test_response = test_client.get(f"{TASK_URL}?task_id=test_id")
@@ -108,8 +107,7 @@ class TestGetTask:
             AsyncResult=pretend.call_recorder(lambda t: mocked_task_result)
         )
         monkeypatch.setattr(
-            "repository_service_tuf_api.tasks.repository_metadata",
-            mocked_repository_metadata,
+            f"{MOCK_PATH}.repository_metadata", mocked_repository_metadata
         )
 
         test_response = test_client.get(f"{TASK_URL}?task_id=test_id")
@@ -144,8 +142,7 @@ class TestGetTask:
             AsyncResult=pretend.call_recorder(lambda t: mocked_task_result)
         )
         monkeypatch.setattr(
-            "repository_service_tuf_api.tasks.repository_metadata",
-            mocked_repository_metadata,
+            f"{MOCK_PATH}.repository_metadata", mocked_repository_metadata
         )
 
         test_response = test_client.get(f"{TASK_URL}?task_id=test_id")
@@ -174,8 +171,7 @@ class TestGetTask:
             AsyncResult=pretend.call_recorder(lambda t: mocked_task_result)
         )
         monkeypatch.setattr(
-            "repository_service_tuf_api.tasks.repository_metadata",
-            mocked_repository_metadata,
+            f"{MOCK_PATH}.repository_metadata", mocked_repository_metadata
         )
 
         test_response = test_client.get(f"{TASK_URL}?task_id=test_id")


### PR DESCRIPTION
# Description

The specification defines `datetime` as UTC time zone:
https://theupdateframework.github.io/specification/latest/#file-formats-date-time

The python-tuf project updated all their datetime objects,  so it's time we do it now as well.

I also used the opportunity to add `MOCK_PATH` constants to simplify mocking and 
`fake_datetime` fixture, so we can reuse it.

# Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.rst).

- [x] I agree to follow this project's Code of Conduct