### PR TITLE
Check first bin names instead of all

### DIFF
--- a/repository_service_tuf_api/metadata.py
+++ b/repository_service_tuf_api/metadata.py
@@ -144,7 +144,10 @@ def post_metadata_online(
         )
 
     delegated_roles = settings_repository.get_fresh("DELEGATED_ROLES_NAMES")
-    bins_used = all(r.startswith(Roles.BINS.value) for r in delegated_roles)
+    # All delegated roles names should start with "bins" if we are using
+    # hash bin delegation and none of the delegated roles should start with
+    # "bins" if we are using custom target delegation.
+    bins_used = True if delegated_roles[0].startswith("bins") else False
     if bins_used:
         # This indicates succinct hash bins are used
         if len(roles) > 0 and any(not Roles.is_role(role) for role in roles):


### PR DESCRIPTION
Check first bin names instead of all.


# Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.rst).

- [x] I agree to follow this project's Code of Conduct