### PR TITLE
feat: Enable RSTUF API to use SigStore for Signatures

### DIFF
--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1804,6 +1804,17 @@
                     "sig": {
                         "type": "string",
                         "title": "Sig"
+                    },
+                    "bundle": {
+                        "anyOf": [
+                            {
+                                "type": "object"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Bundle"
                     }
                 },
                 "type": "object",

--- a/repository_service_tuf_api/common_models.py
+++ b/repository_service_tuf_api/common_models.py
@@ -83,7 +83,7 @@ class TUFSignedDelegationsSuccinctRoles(BaseModel):
 class TUFKeys(BaseModel):
     keytype: str
     scheme: str
-    keyval: Dict[Literal["public"], str]
+    keyval: Dict[Literal["public", "issuer", "identity"], str]
     name: str | None = Field(
         description="Use x-rstuf-key-name instead. Key Name",
         default=None,
@@ -155,6 +155,7 @@ class TUFSigned(BaseModel):
 class TUFSignatures(BaseModel):
     keyid: str
     sig: str
+    bundle: Dict[str, Any] | None = None
 
 
 class TUFMetadata(BaseModel):


### PR DESCRIPTION

# Description

This commit enables RSTUF API to use SigStore signatures in the TUF Metadata.

When using SigStore, the Signature can contain the bundle.

The KeyVal format can contain the issuer and identity used by SigStore

This PR enables API for https://github.com/repository-service-tuf/repository-service-tuf-cli/issues/657
<!--- Please reference the issue(s) this PR fixes. -->


# Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)


# Additional requirements
- [ ] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


# Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.rst).

- [x] I agree to follow this project's Code of Conduct