### PR TITLE
tests: remove FT slow from API

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -77,32 +77,6 @@ jobs:
         run: |
           make ft-das CLI_VERSION=${{ inputs.cli_version }} PYTEST_GROUP=${{ matrix.pytest-group }}
 
-  functional-das-slow:
-      name: "DAS Slow"
-      runs-on: ubuntu-latest
-
-      steps:
-        - name: Checkout RSTUF API source code
-          uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
-
-        - name: Checkout RSTUF Umbrella (FT)
-          uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
-          with:
-            repository: repository-service-tuf/repository-service-tuf
-            path: rstuf-umbrella
-            ref: ${{ inputs.umbrella_branch }}
-
-        - name: Deploy RSTUF with API container from source code
-          uses: isbang/compose-action@e5813a5909aca4ae36058edae58f6e52b9c971f8
-          with:
-            compose-file: ${{ inputs.docker_compose }}
-          env:
-            WORKER_VERSION: ${{ inputs.worker_version }}
-
-        - name: Very slow tests
-          run: |
-            make ft-das CLI_VERSION=${{ inputs.cli_version }} PYTEST_GROUP=none SLOW="yes"
-
   functional-signed:
     name: "Signed"
     runs-on: ubuntu-latest
@@ -131,29 +105,3 @@ jobs:
       - name: Bootstrap/Setup RSTUF full Signed and run Functional Tests
         run: |
           make ft-signed CLI_VERSION=${{ inputs.cli_version }} PYTEST_GROUP=${{ matrix.pytest-group }}
-
-  functional-signed-slow:
-      name: "Signed Slow"
-      runs-on: ubuntu-latest
-
-      steps:
-        - name: Checkout RSTUF API source code
-          uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
-
-        - name: Checkout RSTUF Umbrella (FT)
-          uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
-          with:
-            repository: repository-service-tuf/repository-service-tuf
-            path: rstuf-umbrella
-            ref: ${{ inputs.umbrella_branch }}
-
-        - name: Deploy RSTUF with API container from source code
-          uses: isbang/compose-action@e5813a5909aca4ae36058edae58f6e52b9c971f8
-          with:
-            compose-file: ${{ inputs.docker_compose }}
-          env:
-            WORKER_VERSION: ${{ inputs.worker_version }}
-
-        - name: Very slow tests
-          run: |
-            make ft-signed CLI_VERSION=${{ inputs.cli_version }} PYTEST_GROUP=none SLOW="yes"


### PR DESCRIPTION
Changes in API cannot affect the RSTUF Performance tested in the FT.

The performance is related to managing the TUF Metadata which is done by the RSTUF Worker

<!--- Thanks for taking the time to fill out this pull request! -->
<!--- Please fill in the fields below to submit a pull request. 
The more information provided, the better. -->

<!---  -->

# Description
<!--- What is the PR about? -->


<!--- Please reference the issue(s) this PR fixes. -->
Fixes #(issue)


# Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)


# Additional requirements
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


# Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.rst).

- [ ] I agree to follow this project's Code of Conduct