### PR TITLE
Update return values for GET metadata/sign

### DIFF
--- a/repository_service_tuf_api/metadata.py
+++ b/repository_service_tuf_api/metadata.py
@@ -295,15 +295,6 @@ def get_metadata_sign() -> MetadataSignGetResponse:
     )
 
     md_response = {}
-    trusted_root = settings_repository.get("TRUSTED_ROOT")
-    trusted_targets = settings_repository.get("TRUSTED_TARGETS")
-
-    if trusted_root:
-        md_response["trusted_root"] = trusted_root.to_dict()
-
-    if trusted_targets:
-        md_response["trusted_targets"] = trusted_targets.to_dict()
-
     for role_setting in pending_signing:
         signing_role_obj = settings_repository.get(role_setting)
         if signing_role_obj is not None:
@@ -312,6 +303,15 @@ def get_metadata_sign() -> MetadataSignGetResponse:
             md_response[role] = signing_role_dict
 
     if len(md_response) > 0:
+        # Add trusted_root and trusted_targets only when they are pending.
+        trusted_root = settings_repository.get("TRUSTED_ROOT")
+        trusted_targets = settings_repository.get("TRUSTED_TARGETS")
+        if trusted_root and "root" in md_response:
+            md_response["trusted_root"] = trusted_root.to_dict()
+
+        if trusted_targets and "targets" in md_response:
+            md_response["trusted_targets"] = trusted_targets.to_dict()
+
         data = {"metadata": md_response}
         msg = "Metadata role(s) pending signing"
     else:


### PR DESCRIPTION
# Description
<!--- What is the PR about? -->
Change what we return for GET metadata/sign, so that we return "trusted_root" only when there is pending "root" and "trusted_targets" only when "targets" is pending.

If nothing is pending we don't want to return the "trusted" roles as we do now.


# Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)


# Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.rst).

- [x] I agree to follow this project's Code of Conduct