### PR TITLE
build: Worker config RSTUF_SQL_SERVER -> RSTUF_DB_SERVER

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,7 @@ services:
       - RSTUF_ONLINE_KEY_DIR=/var/opt/repository-service-tuf/key_storage
       - RSTUF_BROKER_SERVER=amqp://guest:guest@rabbitmq:5672
       - RSTUF_REDIS_SERVER=redis://redis
-      - RSTUF_SQL_SERVER=postgresql://postgres:secret@postgres:5432
+      - RSTUF_DB_SERVER=postgresql://postgres:secret@postgres:5432
       - RSTUF_WORKER_ID=dev
     healthcheck:
       test: "exit 0"


### PR DESCRIPTION
Worker config RSTUF_SQL_SERVER -> RSTUF_DB_SERVER in the docker-compose.yml used for tests

# Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.rst).

- [x] I agree to follow this project's Code of Conduct