### PR TITLE
docs: add `make help`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,29 +1,28 @@
 
-.PHONY: all docs tests
+.PHONY: all docs tests clean purge run-dev stop build-dev ft-das ft-signed reformat precommit coverage clone-umbrella help
 
-reformat:
+all: help
+
+reformat:  ## Reformat code with black and isort
 	black -l 79 .
 	isort -l79 --profile black .
 
-tests:
+tests:  ## Run all tests
 	tox -r
 
-requirements:
-	pipenv lock
-
-precommit:
+precommit:  ## Install and run pre-commit hooks
 	pre-commit install
 	pre-commit run --all-files --show-diff-on-failure
 
-coverage:
+coverage:  ## Run tests with coverage
 	coverage report
 	coverage html -i
 
-build-dev:
+build-dev:  ## Build the dev image
 	docker build -t repository-service-tuf-api:dev .
 
 run-dev: export WORKER_VERSION = dev
-run-dev:
+run-dev:  ## Run the development environment
 	$(MAKE) build-dev
 	docker pull ghcr.io/repository-service-tuf/repository-service-tuf-worker:dev
 ifneq ($(DC),)
@@ -32,19 +31,19 @@ else
 	docker compose -f docker-compose.yml up --remove-orphans
 endif
 
-stop:
+stop:  ## Stop the development environment
 	docker compose down -v
 
-clean:
+clean:  ## Clean up the environment
 	$(MAKE) stop
 	docker compose rm --force
 
-purge:
+purge:  ## Remove all images and containers
 	$(MAKE) clean
 	docker rmi repository-service-tuf-api_repository-service-tuf-rest-api --force
 
 
-docs:
+docs:  ## Build the documentation
 	tox -e docs
 
 clone-umbrella:
@@ -68,3 +67,12 @@ ifeq ($(GITHUB_ACTION),)
 	$(MAKE) clone-umbrella
 endif
 	docker compose run --env UMBRELLA_PATH=rstuf-umbrella --entrypoint 'bash rstuf-umbrella/tests/functional/scripts/run-ft-signed.sh $(CLI_VERSION) $(PYTEST_GROUP) $(SLOW)' --rm repository-service-tuf-api
+
+help:  ## Show this help message
+	@echo "Makefile commands:"
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+	awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'	
+	@echo
+	@echo "Environment variables:"
+	@echo "  DC: docker compose file to use (default: docker-compose.yml)"
+


### PR DESCRIPTION
it helps new contributors how to use the `make`

```shell
❯ make
Makefile commands:
reformat                       Reformat code with black and isort
tests                          Run all tests
precommit                      Install and run pre-commit hooks
coverage                       Run tests with coverage
build-dev                      Build the dev image
run-dev                        Run the development environment
stop                           Stop the development environment
clean                          Clean up the environment
purge                          Remove all images and containers
docs                           Build the documentation
help                           Show this help message

Environment variables:
  DC: docker compose file to use (default: docker-compose.yml)
```