### PR TITLE
Updated Docker images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     tty: true
 
   redis:
-    image: redis:4.0
+    image: redis:8.0.0-alpine3.21
     volumes:
       - repository-service-tuf-redis-data:/data
     ports:
@@ -32,7 +32,7 @@ services:
     tty: true
 
   postgres:
-    image: postgres:15.1
+    image: postgres:17.5-alpine3.21
     ports:
       # 5432 may already in use by another PostgreSQL on host
       - "5433:5432"


### PR DESCRIPTION
## Upgrades the docker containers from:

* Postress 15.1 to 17.5
Both have the same vulnerability scores and none of the other images have a lower vulnerability score.

* redis 4.0 to 8.0
The 4.0 image had vulnerabilities while the 8.0 doesn't have any vulnerabilities until now.

### Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.rst).

- [x] I agree to follow this project's Code of Conduct