### PR TITLE
Security hardening: run services as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,15 @@ FROM pre-final
 
 WORKDIR /opt/repository-service-tuf-api
 RUN mkdir /data
+
+RUN groupadd -g 1000 tuf && useradd -r -u 1000 -g tuf tuf
+
 COPY app.py /opt/repository-service-tuf-api
 COPY entrypoint.sh /opt/repository-service-tuf-api
 COPY repository_service_tuf_api /opt/repository-service-tuf-api/repository_service_tuf_api
 COPY tests /opt/repository-service-tuf-api/tests
+
+RUN chown -R tuf:tuf /opt/repository-service-tuf-api /data
+USER 1000
+
 ENTRYPOINT ["bash", "entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,11 +2,11 @@
 #
 
 if [[ -z ${SECRETS_RSTUF_SSL_CERT} ]]; then
-    uvicorn app:rstuf_app --host 0.0.0.0 --port 80
+    uvicorn app:rstuf_app --host 0.0.0.0 --port 8080
 else
     if [[ -z ${SECRETS_RSTUF_SSL_KEY} ]]; then
         echo "Missing variable SECRETS_RSTUF_SSL_KEY"
         exit 1
     fi
-    uvicorn app:rstuf_app --host 0.0.0.0 --port 443 --ssl-keyfile ${SECRETS_RSTUF_SSL_KEY} --ssl-certfile ${SECRETS_RSTUF_SSL_CERT}
+    uvicorn app:rstuf_app --host 0.0.0.0 --port 8443 --ssl-keyfile ${SECRETS_RSTUF_SSL_KEY} --ssl-certfile ${SECRETS_RSTUF_SSL_CERT}
 fi


### PR DESCRIPTION
This change updates the containers to run as a non-root user instead of root.

Summary of changes:
- Created a dedicated user named tuf (UID 1000) inside the containers
- Updated file and directory permissions so the tuf user can access required paths
- Changed internal service ports from 80 to 8080 so root privileges are not required
- Updated container and deployment configuration to enforce non-root execution
- Adjusted supervisor configuration for worker to use writable directories
- Updated Helm charts to set securityContext with runAsNonRoot

Why this change:
Running containers as root is not recommended for security reasons. Running as a non-root user follows container security best practices and reduces risk in production environments.

Testing:
The configuration was verified to ensure the API and Worker can start under non-root permissions and the container setup remains consistent with docker-compose and Helm deployment.

This change is coordinated with the umbrella repository PR:
https://github.com/repository-service-tuf/repository-service-tuf/pull/934