### PR TITLE
Add pydantic Field requirements to API model attributes

### DIFF
--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -728,8 +728,7 @@
                     "length": {
                         "type": "integer",
                         "minimum": 0.0,
-                        "title": "Length",
-                        "description": "Length of the artifact in bytes"
+                        "title": "Length"
                     },
                     "hashes": {
                         "additionalProperties": {
@@ -2109,8 +2108,7 @@
                     "version": {
                         "type": "integer",
                         "minimum": 1.0,
-                        "title": "Version",
-                        "description": "Metadata version number"
+                        "title": "Version"
                     },
                     "spec_version": {
                         "type": "string",
@@ -2226,8 +2224,7 @@
                     "version": {
                         "type": "integer",
                         "minimum": 1.0,
-                        "title": "Version",
-                        "description": "Metadata version number"
+                        "title": "Version"
                     },
                     "spec_version": {
                         "type": "string",
@@ -2396,8 +2393,7 @@
                     "threshold": {
                         "type": "integer",
                         "minimum": 1.0,
-                        "title": "Threshold",
-                        "description": "Minimum number of signatures required"
+                        "title": "Threshold"
                     },
                     "paths": {
                         "items": {
@@ -2459,8 +2455,7 @@
                     "threshold": {
                         "type": "integer",
                         "minimum": 1.0,
-                        "title": "Threshold",
-                        "description": "Minimum number of signatures required"
+                        "title": "Threshold"
                     }
                 },
                 "type": "object",
@@ -2477,8 +2472,7 @@
                     "version": {
                         "type": "integer",
                         "minimum": 1.0,
-                        "title": "Version",
-                        "description": "Metadata version number"
+                        "title": "Version"
                     }
                 },
                 "type": "object",
@@ -2499,8 +2493,7 @@
                     "threshold": {
                         "type": "integer",
                         "minimum": 1.0,
-                        "title": "Threshold",
-                        "description": "Minimum number of signatures required"
+                        "title": "Threshold"
                     }
                 },
                 "type": "object",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -727,7 +727,9 @@
                 "properties": {
                     "length": {
                         "type": "integer",
-                        "title": "Length"
+                        "minimum": 0.0,
+                        "title": "Length",
+                        "description": "Length of the artifact in bytes"
                     },
                     "hashes": {
                         "additionalProperties": {
@@ -823,7 +825,8 @@
                     "timeout": {
                         "anyOf": [
                             {
-                                "type": "integer"
+                                "type": "integer",
+                                "exclusiveMinimum": 0.0
                             },
                             {
                                 "type": "null"
@@ -2105,7 +2108,9 @@
                     },
                     "version": {
                         "type": "integer",
-                        "title": "Version"
+                        "minimum": 1.0,
+                        "title": "Version",
+                        "description": "Metadata version number"
                     },
                     "spec_version": {
                         "type": "string",
@@ -2220,7 +2225,9 @@
                     },
                     "version": {
                         "type": "integer",
-                        "title": "Version"
+                        "minimum": 1.0,
+                        "title": "Version",
+                        "description": "Metadata version number"
                     },
                     "spec_version": {
                         "type": "string",
@@ -2388,7 +2395,9 @@
                     },
                     "threshold": {
                         "type": "integer",
-                        "title": "Threshold"
+                        "minimum": 1.0,
+                        "title": "Threshold",
+                        "description": "Minimum number of signatures required"
                     },
                     "paths": {
                         "items": {
@@ -2449,7 +2458,9 @@
                     },
                     "threshold": {
                         "type": "integer",
-                        "title": "Threshold"
+                        "minimum": 1.0,
+                        "title": "Threshold",
+                        "description": "Minimum number of signatures required"
                     }
                 },
                 "type": "object",
@@ -2465,7 +2476,9 @@
                 "properties": {
                     "version": {
                         "type": "integer",
-                        "title": "Version"
+                        "minimum": 1.0,
+                        "title": "Version",
+                        "description": "Metadata version number"
                     }
                 },
                 "type": "object",
@@ -2485,7 +2498,9 @@
                     },
                     "threshold": {
                         "type": "integer",
-                        "title": "Threshold"
+                        "minimum": 1.0,
+                        "title": "Threshold",
+                        "description": "Minimum number of signatures required"
                     }
                 },
                 "type": "object",

--- a/repository_service_tuf_api/artifacts.py
+++ b/repository_service_tuf_api/artifacts.py
@@ -10,11 +10,7 @@ from typing import Any, Dict, List
 from fastapi import HTTPException, status
 from pydantic import BaseModel, ConfigDict, Field
 
-from repository_service_tuf_api import (
-    bootstrap_state,
-    get_task_id,
-    repository_metadata,
-)
+from repository_service_tuf_api import bootstrap_state, get_task_id, repository_metadata
 
 
 class ResponseData(BaseModel):
@@ -90,7 +86,7 @@ class ResponsePostPublish(BaseModel):
 
 
 class ArtifactInfo(BaseModel):
-    length: int
+    length: int = Field(ge=0, description="Length of the artifact in bytes")
     hashes: Dict[str, str] = Field(
         description=(
             "The key(s) must be compatible with the algorithm(s) supported by "
@@ -162,9 +158,7 @@ def post(payload: AddPayload) -> ResponsePostAdd:
             status.HTTP_404_NOT_FOUND,
             detail={
                 "message": "Task not accepted.",
-                "error": (
-                    f"It requires bootstrap finished. State: {bs_state.state}"
-                ),
+                "error": (f"It requires bootstrap finished. State: {bs_state.state}"),
             },
         )
 
@@ -220,9 +214,7 @@ def delete(payload: DeletePayload) -> ResponsePostDelete:
             status.HTTP_404_NOT_FOUND,
             detail={
                 "message": "Task not accepted.",
-                "error": (
-                    f"It requires bootstrap finished. State: {bs_state.state}"
-                ),
+                "error": (f"It requires bootstrap finished. State: {bs_state.state}"),
             },
         )
 

--- a/repository_service_tuf_api/artifacts.py
+++ b/repository_service_tuf_api/artifacts.py
@@ -10,7 +10,11 @@ from typing import Any, Dict, List
 from fastapi import HTTPException, status
 from pydantic import BaseModel, ConfigDict, Field
 
-from repository_service_tuf_api import bootstrap_state, get_task_id, repository_metadata
+from repository_service_tuf_api import (
+    bootstrap_state,
+    get_task_id,
+    repository_metadata,
+)
 
 
 class ResponseData(BaseModel):
@@ -86,7 +90,7 @@ class ResponsePostPublish(BaseModel):
 
 
 class ArtifactInfo(BaseModel):
-    length: int = Field(ge=0, description="Length of the artifact in bytes")
+    length: int = Field(ge=0)
     hashes: Dict[str, str] = Field(
         description=(
             "The key(s) must be compatible with the algorithm(s) supported by "
@@ -158,7 +162,9 @@ def post(payload: AddPayload) -> ResponsePostAdd:
             status.HTTP_404_NOT_FOUND,
             detail={
                 "message": "Task not accepted.",
-                "error": (f"It requires bootstrap finished. State: {bs_state.state}"),
+                "error": (
+                    f"It requires bootstrap finished. State: {bs_state.state}"
+                ),
             },
         )
 
@@ -214,7 +220,9 @@ def delete(payload: DeletePayload) -> ResponsePostDelete:
             status.HTTP_404_NOT_FOUND,
             detail={
                 "message": "Task not accepted.",
-                "error": (f"It requires bootstrap finished. State: {bs_state.state}"),
+                "error": (
+                    f"It requires bootstrap finished. State: {bs_state.state}"
+                ),
             },
         )
 

--- a/repository_service_tuf_api/bootstrap.py
+++ b/repository_service_tuf_api/bootstrap.py
@@ -82,7 +82,9 @@ class RolesData(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def validate_delegated_roles_names(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+    def validate_delegated_roles_names(
+        cls, values: Dict[str, Any]
+    ) -> Dict[str, Any]:
         # Validation of custom target delegated names is required as otherwise
         # an attacker can use a custom target name to point to a specific place
         # in a file system and override a file or cause unexpected behavior.
@@ -110,15 +112,21 @@ class BootstrapPayload(BaseModel):
     # Accept metadata as raw dicts to preserve canonical JSON
     # Don't parse into TUFMetadata model which would reorder keys
     metadata: Dict[str, Dict[str, Any]]
-    timeout: int | None = Field(default=300, gt=0, description="Timeout in seconds")
+    timeout: int | None = Field(
+        default=300, gt=0, description="Timeout in seconds"
+    )
 
     @model_validator(mode="before")
     @classmethod
-    def validate_signed_extension_fields(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+    def validate_signed_extension_fields(
+        cls, values: Dict[str, Any]
+    ) -> Dict[str, Any]:
         metadata = values.get("metadata")
         if not isinstance(metadata, dict):
             return values
-        known_fields = {v.alias or f for f, v in TUFSigned.model_fields.items()}
+        known_fields = {
+            v.alias or f for f, v in TUFSigned.model_fields.items()
+        }
         for role_md in metadata.values():
             if not isinstance(role_md, dict):
                 continue
@@ -228,7 +236,10 @@ def post_bootstrap(payload: BootstrapPayload) -> BootstrapPostResponse:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=BaseErrorResponse(
-                error=("System already has a Metadata. " f"State: {bs_state.state}")
+                error=(
+                    "System already has a Metadata. "
+                    f"State: {bs_state.state}"
+                )
             ).dict(exclude_none=True),
         )
 

--- a/repository_service_tuf_api/bootstrap.py
+++ b/repository_service_tuf_api/bootstrap.py
@@ -82,9 +82,7 @@ class RolesData(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def validate_delegated_roles_names(
-        cls, values: Dict[str, Any]
-    ) -> Dict[str, Any]:
+    def validate_delegated_roles_names(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         # Validation of custom target delegated names is required as otherwise
         # an attacker can use a custom target name to point to a specific place
         # in a file system and override a file or cause unexpected behavior.
@@ -112,19 +110,15 @@ class BootstrapPayload(BaseModel):
     # Accept metadata as raw dicts to preserve canonical JSON
     # Don't parse into TUFMetadata model which would reorder keys
     metadata: Dict[str, Dict[str, Any]]
-    timeout: int | None = Field(default=300, description="Timeout in seconds")
+    timeout: int | None = Field(default=300, gt=0, description="Timeout in seconds")
 
     @model_validator(mode="before")
     @classmethod
-    def validate_signed_extension_fields(
-        cls, values: Dict[str, Any]
-    ) -> Dict[str, Any]:
+    def validate_signed_extension_fields(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         metadata = values.get("metadata")
         if not isinstance(metadata, dict):
             return values
-        known_fields = {
-            v.alias or f for f, v in TUFSigned.model_fields.items()
-        }
+        known_fields = {v.alias or f for f, v in TUFSigned.model_fields.items()}
         for role_md in metadata.values():
             if not isinstance(role_md, dict):
                 continue
@@ -234,10 +228,7 @@ def post_bootstrap(payload: BootstrapPayload) -> BootstrapPostResponse:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=BaseErrorResponse(
-                error=(
-                    "System already has a Metadata. "
-                    f"State: {bs_state.state}"
-                )
+                error=("System already has a Metadata. " f"State: {bs_state.state}")
             ).dict(exclude_none=True),
         )
 

--- a/repository_service_tuf_api/common_models.py
+++ b/repository_service_tuf_api/common_models.py
@@ -56,19 +56,15 @@ class Roles(Enum):
 
 class BaseErrorResponse(BaseModel):
     error: str = Field(description="Error message")
-    details: Dict[str, str] | None = Field(
-        description="Error details", default=None
-    )
-    code: int | None = Field(
-        description="Error code if available", default=None
-    )
+    details: Dict[str, str] | None = Field(description="Error details", default=None)
+    code: int | None = Field(description="Error code if available", default=None)
 
 
 class TUFSignedDelegationsRoles(BaseModel):
     name: str
     terminating: bool
     keyids: List[str]
-    threshold: int
+    threshold: int = Field(ge=1, description="Minimum number of signatures required")
     paths: List[str] | None = None
     path_hash_prefixes: List[str] | None = None
     x_rstuf_expire_policy: int = Field(
@@ -94,7 +90,7 @@ class TUFSignedDelegationsSuccinctRoles(BaseModel):
     bit_length: int = Field(gt=0, lt=15)
     name_prefix: str
     keyids: List[str]
-    threshold: int
+    threshold: int = Field(ge=1, description="Minimum number of signatures required")
 
 
 class TUFKeys(BaseModel):
@@ -122,12 +118,12 @@ class TUFSignedDelegations(BaseModel):
 
 
 class TUFSignedMetaFile(BaseModel):
-    version: int
+    version: int = Field(ge=1, description="Metadata version number")
 
 
 class TUFSignedRoles(BaseModel):
     keyids: List[str]
-    threshold: int
+    threshold: int = Field(ge=1, description="Minimum number of signatures required")
 
 
 class TUFSigned(BaseModel):
@@ -136,7 +132,7 @@ class TUFSigned(BaseModel):
     )
 
     type: str = Field(alias="_type")
-    version: int
+    version: int = Field(ge=1, description="Metadata version number")
     spec_version: str
     expires: str
     keys: Dict[str, TUFKeys] | None = None
@@ -149,19 +145,12 @@ class TUFSigned(BaseModel):
     # Custom Validator for the extra fields (TUF unrecognized_fields)
     @model_validator(mode="before")
     @classmethod
-    def validate_unrecognized_fields(
-        cls, values: Dict[str, Any]
-    ) -> Dict[str, Any]:
-        all_required_field_names = {
-            v.alias or f for f, v in cls.model_fields.items()
-        }
+    def validate_unrecognized_fields(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        all_required_field_names = {v.alias or f for f, v in cls.model_fields.items()}
 
         for field_name in values:
             if field_name not in all_required_field_names:
-                if (
-                    not field_name.startswith("x")
-                    or len(field_name.split("-")) < 3
-                ):
+                if not field_name.startswith("x") or len(field_name.split("-")) < 3:
                     raise ValueError(
                         f"Invalid: `{field_name}` field name, "
                         "unrecognized_field must use format x-<vendor>-<name>"

--- a/repository_service_tuf_api/common_models.py
+++ b/repository_service_tuf_api/common_models.py
@@ -56,15 +56,19 @@ class Roles(Enum):
 
 class BaseErrorResponse(BaseModel):
     error: str = Field(description="Error message")
-    details: Dict[str, str] | None = Field(description="Error details", default=None)
-    code: int | None = Field(description="Error code if available", default=None)
+    details: Dict[str, str] | None = Field(
+        description="Error details", default=None
+    )
+    code: int | None = Field(
+        description="Error code if available", default=None
+    )
 
 
 class TUFSignedDelegationsRoles(BaseModel):
     name: str
     terminating: bool
     keyids: List[str]
-    threshold: int = Field(ge=1, description="Minimum number of signatures required")
+    threshold: int = Field(ge=1)
     paths: List[str] | None = None
     path_hash_prefixes: List[str] | None = None
     x_rstuf_expire_policy: int = Field(
@@ -90,7 +94,7 @@ class TUFSignedDelegationsSuccinctRoles(BaseModel):
     bit_length: int = Field(gt=0, lt=15)
     name_prefix: str
     keyids: List[str]
-    threshold: int = Field(ge=1, description="Minimum number of signatures required")
+    threshold: int = Field(ge=1)
 
 
 class TUFKeys(BaseModel):
@@ -118,12 +122,12 @@ class TUFSignedDelegations(BaseModel):
 
 
 class TUFSignedMetaFile(BaseModel):
-    version: int = Field(ge=1, description="Metadata version number")
+    version: int = Field(ge=1)
 
 
 class TUFSignedRoles(BaseModel):
     keyids: List[str]
-    threshold: int = Field(ge=1, description="Minimum number of signatures required")
+    threshold: int = Field(ge=1)
 
 
 class TUFSigned(BaseModel):
@@ -132,7 +136,7 @@ class TUFSigned(BaseModel):
     )
 
     type: str = Field(alias="_type")
-    version: int = Field(ge=1, description="Metadata version number")
+    version: int = Field(ge=1)
     spec_version: str
     expires: str
     keys: Dict[str, TUFKeys] | None = None
@@ -145,12 +149,19 @@ class TUFSigned(BaseModel):
     # Custom Validator for the extra fields (TUF unrecognized_fields)
     @model_validator(mode="before")
     @classmethod
-    def validate_unrecognized_fields(cls, values: Dict[str, Any]) -> Dict[str, Any]:
-        all_required_field_names = {v.alias or f for f, v in cls.model_fields.items()}
+    def validate_unrecognized_fields(
+        cls, values: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        all_required_field_names = {
+            v.alias or f for f, v in cls.model_fields.items()
+        }
 
         for field_name in values:
             if field_name not in all_required_field_names:
-                if not field_name.startswith("x") or len(field_name.split("-")) < 3:
+                if (
+                    not field_name.startswith("x")
+                    or len(field_name.split("-")) < 3
+                ):
                     raise ValueError(
                         f"Invalid: `{field_name}` field name, "
                         "unrecognized_field must use format x-<vendor>-<name>"

--- a/tests/unit/api/test_common_models.py
+++ b/tests/unit/api/test_common_models.py
@@ -1,6 +1,15 @@
 import pretend
+import pytest
+from pydantic import ValidationError
 
 from repository_service_tuf_api import common_models
+from repository_service_tuf_api.artifacts import ArtifactInfo
+from repository_service_tuf_api.common_models import (
+    TUFSignedDelegationsRoles,
+    TUFSignedDelegationsSuccinctRoles,
+    TUFSignedMetaFile,
+    TUFSignedRoles,
+)
 
 COMMON_MODELS_PATH = "repository_service_tuf_api.common_models"
 
@@ -89,3 +98,102 @@ class TestRoles:
         all_roles = [1, None, True, [], {}]
         for role in all_roles:
             assert common_models.Roles.is_role(role) is False
+
+
+class TestTUFSignedDelegationsRolesThreshold:
+    def test_threshold_valid(self):
+        role = TUFSignedDelegationsRoles(
+            name="test",
+            terminating=False,
+            keyids=["abc123"],
+            threshold=1,
+            paths=["*"],
+        )
+        assert role.threshold == 1
+
+    def test_threshold_zero_rejected(self):
+        with pytest.raises(ValidationError):
+            TUFSignedDelegationsRoles(
+                name="test",
+                terminating=False,
+                keyids=["abc123"],
+                threshold=0,
+                paths=["*"],
+            )
+
+    def test_threshold_negative_rejected(self):
+        with pytest.raises(ValidationError):
+            TUFSignedDelegationsRoles(
+                name="test",
+                terminating=False,
+                keyids=["abc123"],
+                threshold=-1,
+                paths=["*"],
+            )
+
+
+class TestTUFSignedDelegationsSuccinctRolesThreshold:
+    def test_threshold_valid(self):
+        role = TUFSignedDelegationsSuccinctRoles(
+            bit_length=4,
+            name_prefix="bins",
+            keyids=["abc123"],
+            threshold=1,
+        )
+        assert role.threshold == 1
+
+    def test_threshold_zero_rejected(self):
+        with pytest.raises(ValidationError):
+            TUFSignedDelegationsSuccinctRoles(
+                bit_length=4,
+                name_prefix="bins",
+                keyids=["abc123"],
+                threshold=0,
+            )
+
+
+class TestTUFSignedMetaFileVersion:
+    def test_version_valid(self):
+        meta = TUFSignedMetaFile(version=1)
+        assert meta.version == 1
+
+    def test_version_zero_rejected(self):
+        with pytest.raises(ValidationError):
+            TUFSignedMetaFile(version=0)
+
+    def test_version_negative_rejected(self):
+        with pytest.raises(ValidationError):
+            TUFSignedMetaFile(version=-1)
+
+
+class TestTUFSignedRolesThreshold:
+    def test_threshold_valid(self):
+        role = TUFSignedRoles(keyids=["abc123"], threshold=1)
+        assert role.threshold == 1
+
+    def test_threshold_zero_rejected(self):
+        with pytest.raises(ValidationError):
+            TUFSignedRoles(keyids=["abc123"], threshold=0)
+
+
+class TestArtifactInfoLength:
+    def test_length_valid_zero(self):
+        info = ArtifactInfo(
+            length=0,
+            hashes={"sha256": "abc123"},
+        )
+        assert info.length == 0
+
+    def test_length_valid_positive(self):
+        info = ArtifactInfo(
+            length=1024,
+            hashes={"sha256": "abc123"},
+        )
+        assert info.length == 1024
+
+    def test_length_negative_rejected(self):
+        with pytest.raises(ValidationError):
+            ArtifactInfo(
+                length=-1,
+                hashes={"sha256": "abc123"},
+            )

--- a/tests/unit/api/test_common_models.py
+++ b/tests/unit/api/test_common_models.py
@@ -90,7 +90,15 @@ class TestRoles:
             assert common_models.Roles.is_role(role) is True
 
     def test_is_role_false_str(self):
-        all_roles = ["root1", "1root", "root.json", "f", "bin", "bin0", ""]
+        all_roles = [
+            "root1",
+            "1root",
+            "root.json",
+            "f",
+            "bin",
+            "bin0",
+            "",
+        ]
         for role in all_roles:
             assert common_models.Roles.is_role(role) is False
 


### PR DESCRIPTION
# Description

Adds pydantic `Field()` constraints to model attributes that previously accepted any integer without validation, as described in #520.

| Model | Field | Constraint | Rationale |
|-------|-------|-----------|-----------|
| `TUFSignedDelegationsRoles` | `threshold` | `ge=1` | TUF spec: ≥1 signature required |
| `TUFSignedDelegationsSuccinctRoles` | `threshold` | `ge=1` | Same |
| `TUFSignedRoles` | `threshold` | `ge=1` | Same |
| `TUFSignedMetaFile` | `version` | `ge=1` | TUF spec: versions start at 1 |
| `TUFSigned` | `version` | `ge=1` | Same |
| `ArtifactInfo` | `length` | `ge=0` | Cannot be negative |
| `BootstrapPayload` | `timeout` | `gt=0` | Must be positive |

**Tests:** 13 new unit tests, 99 total pass, `tox -e lint` clean.

**Docs:** Regenerated `docs/swagger.json`.