### PR TITLE
feat: implement database-backed configuration for Redis-less operation

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,8 @@ dynaconf = "*"
 celery = "*"
 python-multipart = "*"
 redis = "*"
+sqlalchemy = "*"
+psycopg2-binary = "*"
 
 [dev-packages]
 black = "*"

--- a/repository_service_tuf_api/__init__.py
+++ b/repository_service_tuf_api/__init__.py
@@ -11,6 +11,7 @@ from uuid import uuid4
 from celery import Celery
 from dynaconf import Dynaconf
 from dynaconf.loaders import redis_loader
+from repository_service_tuf_api import loaders as db_loader
 
 logging.basicConfig(
     level=logging.DEBUG,
@@ -33,15 +34,28 @@ class BootstrapState:
 
 settings = Dynaconf(envvar_prefix="RSTUF")
 
-settings_repository = Dynaconf(
-    redis_enabled=True,
-    redis={
-        "host": settings.REDIS_SERVER.split("redis://")[1],
-        "port": settings.get("REDIS_SERVER_PORT", 6379),
-        "db": settings.get("REDIS_SERVER_DB_REPO_SETTINGS", 1),
-        "decode_responses": True,
-    },
-)
+if settings.get("REDIS_SERVER"):
+    # Host can be redis://redis or just redis
+    redis_server = settings.REDIS_SERVER
+    if "://" in redis_server:
+        host = redis_server.split("://")[1]
+    else:
+        host = redis_server
+
+    settings_repository = Dynaconf(
+        redis_enabled=True,
+        redis={
+            "host": host,
+            "port": settings.get("REDIS_SERVER_PORT", 6379),
+            "db": settings.get("REDIS_SERVER_DB_REPO_SETTINGS", 1),
+            "decode_responses": True,
+        },
+    )
+else:
+    settings_repository = Dynaconf(
+        loaders=["repository_service_tuf_api.loaders"],
+        DB_SERVER=settings.get("DB_SERVER"),
+    )
 secrets_settings = Dynaconf(
     envvar_prefix="SECRETS_RSTUF",
     environments=True,
@@ -54,6 +68,8 @@ celery.conf.result_backend = (
     f"{settings.REDIS_SERVER}"
     f":{settings.get('REDIS_SERVER_PORT', 6379)}"
     f"/{settings.get('REDIS_SERVER_DB_RESULT', 0)}"
+    if settings.get("REDIS_SERVER")
+    else f"db+{settings.DB_SERVER}"
 )
 celery.conf.accept_content = ["json", "application/json"]
 celery.conf.task_serializer = "json"
@@ -80,7 +96,10 @@ def pre_lock_bootstrap(task_id):
         env=settings_repository.current_env
     )
     settings_data["BOOTSTRAP"] = f"pre-{task_id}"
-    redis_loader.write(settings_repository, settings_data)
+    if settings.get("REDIS_SERVER"):
+        redis_loader.write(settings_repository, settings_data)
+    else:
+        db_loader.write(settings_repository, settings_data)
 
 
 def release_bootstrap_lock():
@@ -93,7 +112,10 @@ def release_bootstrap_lock():
         env=settings_repository.current_env
     )
     settings_data["BOOTSTRAP"] = None
-    redis_loader.write(settings_repository, settings_data)
+    if settings.get("REDIS_SERVER"):
+        redis_loader.write(settings_repository, settings_data)
+    else:
+        db_loader.write(settings_repository, settings_data)
 
 
 def bootstrap_state() -> BootstrapState:

--- a/repository_service_tuf_api/loaders.py
+++ b/repository_service_tuf_api/loaders.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: 2023-2025 Repository Service for TUF Contributors
+#
+# SPDX-License-Identifier: MIT
+import logging
+from typing import Any, Dict
+
+from sqlalchemy import Column, String, create_engine
+from sqlalchemy.dialects.postgresql import JSON
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+
+Base = declarative_base()
+
+class RSTUFSettings(Base):
+    __tablename__ = "rstuf_settings"
+    key = Column(String, primary_key=True)
+    value = Column(JSON, nullable=False)
+
+
+def load(obj, env=None, silent=True, key=None, filename=None):
+    """
+    Reads and loads in to "obj" a single key or all keys from database.
+    """
+    db_server = obj.get("DB_SERVER")
+    if not db_server:
+        logging.debug("DB_SERVER not found in settings, skipping DB loader")
+        return
+
+    try:
+        engine = create_engine(db_server)
+        SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+        with SessionLocal() as session:
+            if key:
+                setting = session.query(RSTUFSettings).filter_by(key=key).first()
+                if setting:
+                    obj.update({key: setting.value})
+            else:
+                settings = session.query(RSTUFSettings).all()
+                data = {s.key: s.value for s in settings}
+                obj.update(data)
+    except Exception as e:
+        if not silent:
+            raise e
+        logging.error(f"Error loading settings from DB: {e}")
+
+def write(obj, data: Dict[str, Any]):
+    """
+    Writes data to database.
+    """
+    db_server = obj.get("DB_SERVER")
+    if not db_server:
+        raise AttributeError("DB_SERVER not found in settings")
+
+    engine = create_engine(db_server)
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    with SessionLocal() as session:
+        for key, value in data.items():
+            setting = session.query(RSTUFSettings).filter_by(key=key).first()
+            if setting:
+                setting.value = value
+            else:
+                setting = RSTUFSettings(key=key, value=value)
+                session.add(setting)
+        session.commit()


### PR DESCRIPTION
## Summary

Adds support for database-backed configuration in the API, making Redis optional.

## What changed

- Added a custom Dynaconf loader using PostgreSQL
- API now falls back to DB when Redis is not configured
- Updated bootstrap state handling to support both modes
- Added required DB dependencies

## Behavior

- Redis present → existing behavior
- Redis missing → DB used automatically

## Notes

Complements worker-side changes for Redis optionality.

Ref: repository-service-tuf/repository-service-tuf#777