### PR TITLE
chore: apply security audit improvements (CR-100, CR-111, CR-101)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base
-FROM python:3.13-slim AS base_os
+FROM python:3.14-slim AS base_os
 
 # Builder requirements and deps
 FROM base_os AS builder
@@ -29,16 +29,23 @@ RUN apt-get remove gcc --purge -y \
 
 # Final image
 FROM base_os AS pre-final
-COPY --from=builder /usr/local/lib/python3.13/site-packages /usr/local/lib/python3.13/site-packages/
+COPY --from=builder /usr/local/lib/python3.14/site-packages /usr/local/lib/python3.14/site-packages/
 COPY --from=builder /usr/local/bin /usr/local/bin/
 
 # Final stage
 FROM pre-final
 
+# Create a non-root user
+RUN addgroup --system rstuf && adduser --system --group rstuf
+
 WORKDIR /opt/repository-service-tuf-api
-RUN mkdir /data
-COPY app.py /opt/repository-service-tuf-api
-COPY entrypoint.sh /opt/repository-service-tuf-api
-COPY repository_service_tuf_api /opt/repository-service-tuf-api/repository_service_tuf_api
-COPY tests /opt/repository-service-tuf-api/tests
+RUN mkdir /data && chown rstuf:rstuf /data
+
+COPY --chown=rstuf:rstuf app.py /opt/repository-service-tuf-api
+COPY --chown=rstuf:rstuf entrypoint.sh /opt/repository-service-tuf-api
+COPY --chown=rstuf:rstuf repository_service_tuf_api /opt/repository-service-tuf-api/repository_service_tuf_api
+COPY --chown=rstuf:rstuf tests /opt/repository-service-tuf-api/tests
+
+USER rstuf
+
 ENTRYPOINT ["bash", "entrypoint.sh"]

--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,7 @@ dynaconf = "*"
 celery = "*"
 python-multipart = "*"
 redis = "*"
+jinja2 = ">=3.1.6"
 
 [dev-packages]
 black = "*"
@@ -40,4 +41,4 @@ bandit = "*"
 httpx = "*"
 
 [requires]
-python_version = "3.13"
+python_version = "3.14"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py3.13,requirements,precommit,lint,test,test-docs
+envlist = py3.14,requirements,precommit,lint,test,test-docs
 
 [testenv]
 setenv =
@@ -82,4 +82,4 @@ commands =
 
 [gh-actions]
 python =
-    3.13: py3.13,pep8,lint,precommit,test,test-docs
+    3.14: py3.14,pep8,lint,precommit,test,test-docs


### PR DESCRIPTION
## Description

This PR applies a set of improvements based on the RSTUF security audit findings.

Changes included:
- Pin jinja2 to version >= 3.1.6 to avoid outdated dependency usage
- Run the API container as a non-root user (rstuf)
- Update the base image to Python 3.14

These updates improve dependency safety and container security without affecting existing functionality.

## Reference
Security Audit Parent Issue:
https://github.com/repository-service-tuf/repository-service-tuf/issues/852