### PR TITLE
feat: support custom delegated targets using offline keys (#647)

### DIFF
--- a/repository_service_tuf_api/api/delegations.py
+++ b/repository_service_tuf_api/api/delegations.py
@@ -59,3 +59,22 @@ def put_delegation(payload: delegations.MetadataDelegationsPayload):
 )
 def delete_delegation(payload: delegations.MetadataDelegationDeletePayload):
     return delegations.metadata_delegation(payload, action="delete")
+
+
+@router.post(
+    "/metadata",
+    summary="Post a task to create a new custom delegation with metadata.",
+    description=(
+        "Submit an asynchronous task to create a new custom delegation with "
+        "pre-signed metadata. "
+        "Use the task ID to retrieve the task status in the endpoint "
+        "/api/v1/task."
+    ),
+    response_model=delegations.DelegationsResponse,
+    response_model_exclude_none=True,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+def post_delegation_metadata(
+    payload: delegations.MetadataDelegatedCustomPayload,
+):
+    return delegations.metadata_delegation(payload, action="add")

--- a/repository_service_tuf_api/delegations.py
+++ b/repository_service_tuf_api/delegations.py
@@ -14,7 +14,7 @@ from repository_service_tuf_api import (
     get_task_id,
     repository_metadata,
 )
-from repository_service_tuf_api.common_models import TUFDelegations
+from repository_service_tuf_api.common_models import TUFDelegations, TUFMetadata
 
 with open("tests/data_examples/metadata/delegation-payload.json") as f:
     content = f.read()
@@ -72,11 +72,39 @@ class MetadataDelegationDeletePayload(BaseModel):
         }
     )
 
-    delegations: DelegationsData
+class MetadataDelegatedCustomPayload(BaseModel):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "metadata": {
+                    "signatures": [
+                        {
+                            "keyid": "keyid1",
+                            "sig": "signature1"
+                        }
+                    ],
+                    "signed": {
+                        "_type": "targets",
+                        "version": 1,
+                        "spec_version": "1.0.31",
+                        "expires": "2025-01-01T00:00:00Z",
+                        "targets": {}
+                    }
+                }
+            }
+        }
+    )
+
+    rolename: str
+    metadata: TUFMetadata
 
 
 def metadata_delegation(
-    payload: MetadataDelegationsPayload | MetadataDelegationDeletePayload,
+    payload: (
+        MetadataDelegationsPayload
+        | MetadataDelegationDeletePayload
+        | MetadataDelegatedCustomPayload
+    ),
     action: str,
 ):
     bs_state = bootstrap_state()

--- a/repository_service_tuf_api/delegations.py
+++ b/repository_service_tuf_api/delegations.py
@@ -76,6 +76,7 @@ class MetadataDelegatedCustomPayload(BaseModel):
     model_config = ConfigDict(
         json_schema_extra={
             "example": {
+                "rolename": "dev",
                 "metadata": {
                     "signatures": [
                         {
@@ -87,7 +88,7 @@ class MetadataDelegatedCustomPayload(BaseModel):
                         "_type": "targets",
                         "version": 1,
                         "spec_version": "1.0.31",
-                        "expires": "2025-01-01T00:00:00Z",
+                        "expires": "2030-01-01T00:00:00Z",
                         "targets": {}
                     }
                 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,0 @@
-fastapi
-uvicorn
-dynaconf
-celery
-python-multipart
-redis
-tuf
-pydantic

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+fastapi
+uvicorn
+dynaconf
+celery
+python-multipart
+redis
+tuf
+pydantic

--- a/tests/data_examples/metadata/delegated-targets-payload.json
+++ b/tests/data_examples/metadata/delegated-targets-payload.json
@@ -1,23 +1,22 @@
 {
+    "rolename": "dev",
     "metadata": {
-        "dev": {
-            "signatures": [
-                {
-                    "keyid": "2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241",
-                    "sig": "7561c1db8a1f5e27de475f6b1f8f0d6fff7f53957784f689d86cab9a76de2adf48c5e2573e81b6f5bda6c4b9fb6611df985f08d7d27e22e31c73833ec130b505b3da02a78c6b730a3ebf21b4878f4067ddbd153f8f498e5787f2e9fd29dd4564358795664b33572919fb2f2a22f25182d83da4e5109d5067198bb85e20bff1385a06821e93362dfbfbc1e1820965c8e555c228c27b2c4c697936c2036b163b2ce126c9dc936ed66c38cda504062bc88c017790ccb9c78fd6fcc06f329cfaf17dc4e72343c9de17b12fc699f894868bbfff5b8437939442dfd2887e0244038583ec6b9fd7f96247b6d45b3700c1b04028e04779870afb473782be9e422551a371"
-                }
-            ],
-            "signed": {
-                "_type": "targets",
-                "version": 1,
-                "spec_version": "1.0.31",
-                "expires": "2030-01-01T00:00:00Z",
-                "targets": {
-                    "file1.txt": {
-                        "length": 10,
-                        "hashes": {
-                            "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-                        }
+        "signatures": [
+            {
+                "keyid": "2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241",
+                "sig": "7561c1db8a1f5e27de475f6b1f8f0d6fff7f53957784f689d86cab9a76de2adf48c5e2573e81b6f5bda6c4b9fb6611df985f08d7d27e22e31c73833ec130b505b3da02a78c6b730a3ebf21b4878f4067ddbd153f8f498e5787f2e9fd29dd4564358795664b33572919fb2f2a22f25182d83da4e5109d5067198bb85e20bff1385a06821e93362dfbfbc1e1820965c8e555c228c27b2c4c697936c2036b163b2ce126c9dc936ed66c38cda504062bc88c017790ccb9c78fd6fcc06f329cfaf17dc4e72343c9de17b12fc699f894868bbfff5b8437939442dfd2887e0244038583ec6b9fd7f96247b6d45b3700c1b04028e04779870afb473782be9e422551a371"
+            }
+        ],
+        "signed": {
+            "_type": "targets",
+            "version": 1,
+            "spec_version": "1.0.31",
+            "expires": "2030-01-01T00:00:00Z",
+            "targets": {
+                "file1.txt": {
+                    "length": 10,
+                    "hashes": {
+                        "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                     }
                 }
             }

--- a/tests/data_examples/metadata/delegated-targets-payload.json
+++ b/tests/data_examples/metadata/delegated-targets-payload.json
@@ -1,0 +1,26 @@
+{
+    "metadata": {
+        "dev": {
+            "signatures": [
+                {
+                    "keyid": "2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241",
+                    "sig": "7561c1db8a1f5e27de475f6b1f8f0d6fff7f53957784f689d86cab9a76de2adf48c5e2573e81b6f5bda6c4b9fb6611df985f08d7d27e22e31c73833ec130b505b3da02a78c6b730a3ebf21b4878f4067ddbd153f8f498e5787f2e9fd29dd4564358795664b33572919fb2f2a22f25182d83da4e5109d5067198bb85e20bff1385a06821e93362dfbfbc1e1820965c8e555c228c27b2c4c697936c2036b163b2ce126c9dc936ed66c38cda504062bc88c017790ccb9c78fd6fcc06f329cfaf17dc4e72343c9de17b12fc699f894868bbfff5b8437939442dfd2887e0244038583ec6b9fd7f96247b6d45b3700c1b04028e04779870afb473782be9e422551a371"
+                }
+            ],
+            "signed": {
+                "_type": "targets",
+                "version": 1,
+                "spec_version": "1.0.31",
+                "expires": "2030-01-01T00:00:00Z",
+                "targets": {
+                    "file1.txt": {
+                        "length": 10,
+                        "hashes": {
+                            "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/unit/api/test_delegations.py
+++ b/tests/unit/api/test_delegations.py
@@ -245,3 +245,67 @@ class TestDeleteDelegationAPI:
         assert (
             "Requires bootstrap finished" in response.json()["detail"]["error"]
         )
+class TestPostDelegationMetadataAPI:
+    def test_post_delegation_metadata(
+        self, test_client, monkeypatch, fake_datetime
+    ):
+        """
+        Test creating a new delegation with metadata via
+        POST /api/v1/delegations/metadata
+        """
+        # Mock bootstrap_state to return a bootstrapped state
+        monkeypatch.setattr(
+            f"{MOCK_PATH}.bootstrap_state",
+            pretend.call_recorder(
+                lambda: BootstrapState(bootstrap=True, state="FINISHED")
+            ),
+        )
+
+        # Mock get_task_id to return a deterministic task ID
+        monkeypatch.setattr(
+            f"{MOCK_PATH}.get_task_id",
+            pretend.call_recorder(lambda: "fake_task_id"),
+        )
+
+        # Mock repository_metadata.apply_async
+        mock_apply_async = pretend.call_recorder(lambda **kw: None)
+        monkeypatch.setattr(
+            f"{MOCK_PATH}.repository_metadata",
+            pretend.stub(apply_async=mock_apply_async),
+        )
+
+        # Mock datetime
+        monkeypatch.setattr(f"{MOCK_PATH}.datetime", fake_datetime)
+
+        # Create payload
+        payload = {
+            "rolename": "dev",
+            "metadata": {
+                "signatures": [{"keyid": "k1", "sig": "s1"}],
+                "signed": {
+                    "_type": "targets",
+                    "version": 1,
+                    "spec_version": "1.0.31",
+                    "expires": "2025-01-01T00:00:00Z",
+                    "targets": {},
+                },
+            },
+        }
+
+        # Make API request
+        url = f"{DELEGATIONS_URL}metadata"
+        response = test_client.post(url, json=payload)
+
+        # Verify response
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        assert response.json()["message"] == "Metadata delegation add accepted."
+        assert response.json()["data"]["task_id"] == "fake_task_id"
+
+        # Verify mocks were called correctly
+        assert mock_apply_async.calls
+        call_kwargs = mock_apply_async.calls[0].kwargs
+        assert call_kwargs["task_id"] == "fake_task_id"
+        assert call_kwargs["kwargs"]["action"] == "metadata_delegation"
+        assert call_kwargs["kwargs"]["payload"]["action"] == "add"
+        assert call_kwargs["kwargs"]["payload"]["rolename"] == "dev"
+        assert "metadata" in call_kwargs["kwargs"]["payload"]


### PR DESCRIPTION
# Description

This PR introduces support for submitting pre-signed delegated targets metadata
using offline keys, as proposed in issue #647.

A new endpoint has been added to allow users to provide externally signed
delegated targets metadata, which is then validated and processed asynchronously.

Reference issue:
https://github.com/repository-service-tuf/repository-service-tuf/issues/647

# Changes

- Added new endpoint:
  POST /api/v1/delegations/metadata

- Introduced new payload model:
  MetadataDelegatedCustomPayload

- Extended delegation service to support custom metadata flow

- Ensured strict separation between:
  - standard delegation flow
  - custom metadata delegation flow

# Behavior

- Accepts pre-signed TUF targets metadata
- Submits async task to worker
- Returns task ID for tracking

# Testing

- Added unit test:
  test_post_delegation_metadata

- Verified:
  - 202 Accepted response
  - task creation
  - correct payload forwarding to worker

# Notes

- Changes are minimal and aligned with existing API structure
- No breaking changes introduced

# Type of change
- [x] New feature

# Additional requirements
- [x] Tests added

# Code of Conduct
- [x] I agree to follow this project's Code of Conduct