### PR TITLE
build: pin Dockerfile base image and monitor docker images with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,3 +28,17 @@ updates:
       github-actions:
         patterns:
           - "*"
+  # Monitor Docker base images
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "10:00"
+    commit-message:
+      prefix: "build"
+      include: "scope"
+    open-pull-requests-limit: 10
+    groups:
+      docker:
+        patterns:
+          - "*"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base
-FROM python:3.13-slim AS base_os
+FROM python:3.13-slim@sha256:eb43ff125d8d58d7449dcba7d336c23bcac412f526d861db493b9994d8010280 AS base_os
 
 # Builder requirements and deps
 FROM base_os AS builder


### PR DESCRIPTION
Pins the `python:3.13-slim` base image by digest and adds a `docker` package-ecosystem to dependabot, so base image updates (including future Python version bumps) arrive as dependabot PRs.

The original Python ~~3.14~~ 3.13 bump was dropped from this PR: functional tests cannot pass on3.14 yet because the RSTUF CLI depends on PyKCS11, which has no cp314 wheels until its next release (LudovicRousseau/PyKCS11#155) and its sdist build produces a broken extension on `python:3.14-slim` (`undefined symbol: _ZTVN10__cxxabiv117__class_type_infoE`). The umbrella Pipfile also pins Python 3.13, so a 3.14 move needs to be coordinated across CLI/worker/umbrella once PyKCS11 supports it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)